### PR TITLE
Made title of Divisions history edit page appropriate

### DIFF
--- a/app/views/divisions/history.html.haml
+++ b/app/views/divisions/history.html.haml
@@ -2,14 +2,16 @@
   = Diffy::CSS
 
 - content_for :title do
-  Division Description Changes —
-  = @division.original_name
-  —
-  = formatted_date(@division.date)
+  Division Description Changes
 - set_meta_tags description: "All changes made to the description and title of the division: #{@division.name}"
 
 .page-header
-  %h1= yield :title
+  %h1
+    = yield :title
+  %h2
+    = @division.original_name
+    %small.pre-title
+      = formatted_date(@division.date)
 
 %p
   All changes made to the description and title of this
@@ -41,3 +43,4 @@
           = Diffy::Diff.new(wiki_motion.previous_title.strip, wiki_motion.title.strip).to_s(:html).html_safe
           %p Description
           = Diffy::Diff.new(wiki_motion.previous_description, wiki_motion.description).to_s(:html).html_safe
+

--- a/app/views/divisions/history.html.haml
+++ b/app/views/divisions/history.html.haml
@@ -1,17 +1,16 @@
 %style
   = Diffy::CSS
 
-- content_for :title do
-  Division Description Changes
+- content_for :title, "Division Description Changes"
 - set_meta_tags description: "All changes made to the description and title of the division: #{@division.name}"
 
 .page-header
+  %h1= yield :title
   %h1
-    = yield :title
-  %h2
-    = @division.original_name
-    %small.pre-title
-      = formatted_date(@division.date)
+    .division-title.long-title
+      = @division.original_name
+      %small.pre-title
+        = formatted_date(@division.date)
 
 %p
   All changes made to the description and title of this
@@ -43,4 +42,3 @@
           = Diffy::Diff.new(wiki_motion.previous_title.strip, wiki_motion.title.strip).to_s(:html).html_safe
           %p Description
           = Diffy::Diff.new(wiki_motion.previous_description, wiki_motion.description).to_s(:html).html_safe
-


### PR DESCRIPTION
This commit aims to fix the issue openaustralia#798
The date and title have now been sent to new lines with slightly different layouts to distinguish between them and provide an easy to distinguish title.

This is what it looks like now:
![newtoup](https://cloud.githubusercontent.com/assets/16884926/24589809/ab87ca9e-17fe-11e7-8314-38c9fb5ea977.png)
