### PR TITLE
Add previous member change dates.

### DIFF
--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -65,14 +65,16 @@ module MembersHelper
 
   def member_history_sentence(member)
     out = []
-    out << "Before being "
-    out << member_type_party_place_sentence_without_former(member)
-    out << ", #{member.name} was "
+    out << "#{member.name} has also been "
     # TODO: This looks like it assumes the member is the most recent one. Is that always the case?
     t = member.person.members.order(entered_house: :desc).offset(1).map do |member2, _i|
       out2 = []
       out2 << "#{member2.party_name} "
       out2 << member_type_electorate_sentence(member2)
+      out2 << " (#{member2.entered_display}" + (" " if member2.entered_display.size > 0)
+      out2 << "#{member2.since} - "
+      out2 << member2.left_display + (" " if member2.left_display.size > 0)
+      out2 << "#{member2.until})"
       safe_join(out2)
     end
     out << to_sentence(t)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -83,6 +83,40 @@ class Member < ApplicationRecord
     entered_reason == "changed_party" || left_reason == "changed_party"
   end
 
+  def entered_display
+    case entered_reason
+    when "changed_party"
+      "changed party"
+    when "general_election", "by_election"
+      "elected"
+    when "unknown"
+      ""
+    else
+      entered_reason or ""
+    end
+  end
+
+  def left_display
+    case left_reason
+    when "general_election", "by_election"
+      "elected"
+    when "still_in_office", "unknown"
+      ""
+    when "changed_party"
+      "changed party"
+    when "resigned"
+      "resigned"
+    when "disqualified", "declared_void"
+      "disqualified"
+    when "died"
+      "died"
+    when "retired"
+      "retired"
+    else
+      left_reason or ""
+    end
+  end
+
   def divisions_they_could_have_attended
     Division.possible_for_member(self).order(date: :desc, clock_time: :desc, name: :asc)
   end


### PR DESCRIPTION
Includes the reason for the changes.
Closes #961

Before:
![image](https://user-images.githubusercontent.com/441771/156878863-3cd133de-9ca8-40c4-a024-a861fabbfedc.png)


After:
![image](https://user-images.githubusercontent.com/441771/156878833-94afd16f-4b8f-4e52-b6ea-ead552b8e63a.png)
