### PR TITLE
Support to search for a senator

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -39,7 +39,18 @@ class HomeController < ApplicationController
     elsif params[:button] == "hero_search" && @current_members.include?(params[:query].downcase)
       redirect_to view_context.member_path_simple(Member.with_name(params[:query]).first)
     elsif params[:query].present?
-      @mps = Member.search_with_sql_fallback params[:query]
+      res = helpers.house_constituency_from_query(params[:query])
+      if res.empty?
+        @mps = Member.search_with_sql_fallback params[:query]
+      else
+        house, con = res
+        member = Member.current.where(house: house, constituency: con)
+
+        member.each do |m|
+          @mps << m unless m.nil?
+        end
+      end
+
       @divisions = Division.search_with_sql_fallback params[:query]
       @policies = Policy.search_with_sql_fallback params[:query]
     end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,4 +1,39 @@
 # frozen_string_literal: true
 
 module HomeHelper
+  def house_constituency_from_query(query)
+    res = []
+    states = {
+      nsw: "NSW",
+      victoria: "Victoria",
+      vic: "Victoria",
+      wa: "WA",
+      queensland: "Queensland",
+      qld: "Queensland",
+      nt: "NT",
+      sa: "SA",
+      tasmania: "Tasmania",
+      tas: "Tasmania",
+      canberra: "ACT",
+      act: "ACT",
+      "new south wales": "NSW",
+      "western australia": "WA",
+      "northern territory": "NT",
+      "south australia": "SA"
+    }
+
+    return res unless query.downcase.include?("senator") || query.downcase.include?("senate")
+
+    res << "senate"
+
+    states.each_key do |key|
+      Rails.logger.debug key
+      if query.downcase.include?(key.to_s)
+        res << states[key]
+        break
+      end
+    end
+
+    res
+  end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -52,3 +52,19 @@
 .front-quote-block.banner-section
   .container
     = render "quote"
+
+:javascript
+  input = document.querySelectorAll('.form-control#query')[1]
+  vals = ['e.g. Senate for Tasmania', 'e.g. Senate for NSW']
+  index = 0
+
+  current_placeholder = input.getAttribute('placeholder')
+  vals.push(current_placeholder)
+
+  setInterval(updatePlaceholder, 2500);
+
+  function updatePlaceholder() {
+    input.setAttribute('placeholder', vals[index % vals.length])
+    index++
+  }
+  

--- a/spec/fixtures/static_pages/.html
+++ b/spec/fixtures/static_pages/.html
@@ -26,6 +26,7 @@ They Vote For You — How does your MP vote?
 <meta name="twitter:image" content="http://www.example.com/assets/theyvoteforyou_logo_200x200.jpg">
 <meta name="twitter:title" content="How does your MP vote on the issues that matter to you?">
 <meta name="twitter:description" content="Forget what politicians say. What truly matters is what they do. And what they do is vote, to write our laws which affect us all.">
+
 </head>
 <body class='home'>
 <nav class='site-header navbar' role='navigation'>
@@ -243,6 +244,21 @@ This is brilliant stuff. My member is about to get a few "please explain" letter
 
 </div>
 </div>
+<script>
+  input = document.querySelectorAll('.form-control#query')[1]
+  vals = ['e.g. Senate for Tasmania', 'e.g. Senate for NSW']
+  index = 0
+  
+  current_placeholder = input.getAttribute('placeholder')
+  vals.push(current_placeholder)
+  
+  setInterval(updatePlaceholder, 2500);
+  
+  function updatePlaceholder() {
+    input.setAttribute('placeholder', vals[index % vals.length])
+    index++
+  }
+</script>
 
 <footer class='site-footer'>
 <div class='footer-main'>


### PR DESCRIPTION
This PR is a revised version of PR #1329 as that PR had issues with the regression tests as well as an ugly commit history. It relates to issue: https://github.com/openaustralia/publicwhip/issues/1198

The placeholder value rotates between the randomly generated suggestion as well as `e.g. Senate for Tasmania` and `e.g. Senate for NSW` to avoid the placeholder being wider than the width of the input box

Here is what it looks like:

![UI_changes](https://user-images.githubusercontent.com/86769131/152745065-3e678f4d-7128-4cfe-a6ca-520d5538db9a.gif)

The search supports all ways of representing a constituency e.g. `Queensland` or `QLD`

In the case that a user has javascript disabled then the placeholder values wont rotate and the user will not know that the 