### PR TITLE
Only allow staff to edit divisions and policies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,9 @@ gem "bootsnap"
 # To show progress during some long running rake tasks
 gem "ruby-progressbar"
 
+# Authorization
+gem "pundit"
+
 group :test do
   gem "rspec-activemodel-mocks"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,6 +386,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-cors (1.1.1)
@@ -633,6 +635,7 @@ DEPENDENCIES
   numbers_and_words
   oj
   paper_trail
+  pundit
   rack-cors
   rack-livereload
   rack-mini-profiler

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,8 @@ class ApplicationController < ActionController::Base
   after_action :store_location
   before_action :set_paper_trail_whodunnit
 
+  include Pundit::Authorization
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -134,6 +134,7 @@ class DivisionsController < ApplicationController
   def update_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
+    authorize policy_division, :update?
 
     if policy_division.update(policy_division_params)
       flash[:notice] = "Updated policy connection"

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -114,6 +114,7 @@ class DivisionsController < ApplicationController
     end
   end
 
+  # TODO: Move this to a policy_division controller
   def create_policy_division
     @division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     @policy_division = @division.policy_divisions.new(policy_division_params)
@@ -128,6 +129,7 @@ class DivisionsController < ApplicationController
     end
   end
 
+  # TODO: Move this to a policy_division controller
   def update_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
@@ -142,6 +144,7 @@ class DivisionsController < ApplicationController
     redirect_to division_policies_path(house: division.house, date: division.date, number: division.number)
   end
 
+  # TODO: Move this to a policy_division controller
   def destroy_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -118,6 +118,7 @@ class DivisionsController < ApplicationController
   def create_policy_division
     @division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     @policy_division = @division.policy_divisions.new(policy_division_params)
+    authorize @policy_division, :create?
 
     if @policy_division.save
       # TODO: Just point to the object when the path helper has been refactored

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -94,6 +94,7 @@ class DivisionsController < ApplicationController
 
   def edit
     @division = Division.in_house(params[:house] || "representatives").find_by!(date: params[:date], number: params[:number])
+    authorize @division
   end
 
   def history
@@ -102,6 +103,7 @@ class DivisionsController < ApplicationController
 
   def update
     @division = Division.in_house(params[:house] || "representatives").find_by!(date: params[:date], number: params[:number])
+    authorize @division
 
     wiki_motion = @division.build_wiki_motion(params[:newtitle], params[:newdescription], current_user)
 

--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -149,6 +149,7 @@ class DivisionsController < ApplicationController
   def destroy_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
     policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
+    authorize policy_division, :destroy?
 
     if policy_division.destroy
       flash[:notice] = "Removed policy connection"

--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -41,16 +41,19 @@ class PoliciesController < ApplicationController
 
   def edit
     @policy = Policy.find(params[:id])
+    authorize @policy
   end
 
   def new
     @policy = Policy.new
+    authorize @policy
   end
 
   def create
     @policy = Policy.new policy_params
     @policy.user = current_user
     @policy.private = 2
+    authorize @policy
     if @policy.save
       redirect_to @policy, notice: "Successfully made new policy"
     else
@@ -60,6 +63,7 @@ class PoliciesController < ApplicationController
 
   def update
     @policy = Policy.find(params[:id])
+    authorize @policy
 
     if @policy.update policy_params
       @policy.alert_watches(@policy.versions.last)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/division_policy.rb
+++ b/app/policies/division_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DivisionPolicy < ApplicationPolicy
   def update?
     user&.staff?

--- a/app/policies/division_policy.rb
+++ b/app/policies/division_policy.rb
@@ -1,0 +1,18 @@
+class DivisionPolicy < ApplicationPolicy
+  def update?
+    user&.staff?
+  end
+
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/policy_division_policy.rb
+++ b/app/policies/policy_division_policy.rb
@@ -1,0 +1,18 @@
+class PolicyDivisionPolicy < ApplicationPolicy
+  def create?
+    user&.staff?
+  end
+
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/policy_division_policy.rb
+++ b/app/policies/policy_division_policy.rb
@@ -3,6 +3,10 @@ class PolicyDivisionPolicy < ApplicationPolicy
     user&.staff?
   end
 
+  def destroy?
+    user&.staff?
+  end
+
   # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
   # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
   # In most cases the behavior will be identical, but if updating existing

--- a/app/policies/policy_division_policy.rb
+++ b/app/policies/policy_division_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PolicyDivisionPolicy < ApplicationPolicy
   def create?
     user&.staff?

--- a/app/policies/policy_division_policy.rb
+++ b/app/policies/policy_division_policy.rb
@@ -3,6 +3,10 @@ class PolicyDivisionPolicy < ApplicationPolicy
     user&.staff?
   end
 
+  def update?
+    user&.staff?
+  end
+
   def destroy?
     user&.staff?
   end

--- a/app/policies/policy_policy.rb
+++ b/app/policies/policy_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PolicyPolicy < ApplicationPolicy
   def create?
     user&.staff?

--- a/app/policies/policy_policy.rb
+++ b/app/policies/policy_policy.rb
@@ -1,0 +1,22 @@
+class PolicyPolicy < ApplicationPolicy
+  def create?
+    user.staff?
+  end
+
+  def update?
+    create?
+  end
+
+  # NOTE: Up to Pundit v2.3.1, the inheritance was declared as
+  # `Scope < Scope` rather than `Scope < ApplicationPolicy::Scope`.
+  # In most cases the behavior will be identical, but if updating existing
+  # code, beware of possible changes to the ancestors:
+  # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
+
+  class Scope < ApplicationPolicy::Scope
+    # NOTE: Be explicit about which records you allow access to!
+    # def resolve
+    #   scope.all
+    # end
+  end
+end

--- a/app/policies/policy_policy.rb
+++ b/app/policies/policy_policy.rb
@@ -1,6 +1,6 @@
 class PolicyPolicy < ApplicationPolicy
   def create?
-    user.staff?
+    user&.staff?
   end
 
   def update?

--- a/app/policies/policy_policy.rb
+++ b/app/policies/policy_policy.rb
@@ -6,7 +6,7 @@ class PolicyPolicy < ApplicationPolicy
   end
 
   def update?
-    create?
+    user&.staff?
   end
 
   # NOTE: Up to Pundit v2.3.1, the inheritance was declared as

--- a/app/views/divisions/_current_policies_list.html.haml
+++ b/app/views/divisions/_current_policies_list.html.haml
@@ -12,4 +12,5 @@
             voted
             = vote_display PolicyDivision.vote_without_strong(division.policy_division(policy).vote)
 
-= link_to("#{division.policies.empty? ? "Does this division relate to a policy?" : "Add or update related policies"}", division_policies_path(division.url_params), class: 'small division-related-policies-edit-link' , title: "Show or change the polices which vote on this division")
+- if policy(PolicyDivision).new?
+  = link_to("#{division.policies.empty? ? "Does this division relate to a policy?" : "Add or update related policies"}", division_policies_path(division.url_params), class: 'small division-related-policies-edit-link' , title: "Show or change the polices which vote on this division")

--- a/app/views/divisions/_header.html.haml
+++ b/app/views/divisions/_header.html.haml
@@ -3,7 +3,8 @@
 
 .page-header.division-header.row
   %nav.header-actions.col-md-1.col-lg-2
-    = link_to "Edit", edit_division_path_simple(division), title: "Change title and summary of this division", class: "link-division-edit btn btn-default btn-xs"
+    - if policy(division).edit?
+      = link_to "Edit", edit_division_path_simple(division), title: "Change title and summary of this division", class: "link-division-edit btn btn-default btn-xs"
 
   %h1.division-title.col-md-11.col-lg-10.long-title
     %small.pre-title= division_date_and_time(division) + " – " + division.house_name

--- a/app/views/divisions/_motion.html.haml
+++ b/app/views/divisions/_motion.html.haml
@@ -1,11 +1,14 @@
 - if division.edited?
   %section.motion.page-section.col-md-8.col-lg-7{class: division.edited? ? "motion-edited" : "motion-raw collapse"}
     %h2.motion-title Summary
-    = link_to "Edit", edit_division_path_simple(division), title: "Edit and improve this description", class: "link-division-edit division-edit-link btn btn-link btn-xs"
+    - if policy(division).edit?
+      = link_to "Edit", edit_division_path_simple(division), title: "Edit and improve this description", class: "link-division-edit division-edit-link btn btn-link btn-xs"
     .motion-text= division.formatted_motion_text
 - else
   %p.division-edit-notice.alert.alert-warning.page-section.clearfix.col-sm-7
     This division is yet to be summarised. Believe it or not there is no easy to understand explanation of every vote in our parliament.
     If you’d like to know more about this division, reading the
     = link_to "preceding debate", division.debate_url
-    may be helpful. You can help everybody by improving this resource—#{link_to "provide a summary of what was voted on in this division", edit_division_path_simple(division)}.
+    may be helpful.
+    - if policy(division).edit?
+      You can help everybody by improving this resource—#{link_to "provide a summary of what was voted on in this division", edit_division_path_simple(division)}.

--- a/app/views/divisions/show_policies.html.haml
+++ b/app/views/divisions/show_policies.html.haml
@@ -17,22 +17,23 @@
           = f.submit 'Update', class: 'btn btn-primary btn-xs'
         = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy)), method: :delete, class: 'btn btn-sm btn-link'
 
-%h3 Make a new connection
+- if policy(@policy_division).create?
+  %h3 Make a new connection
 
-= simple_form_for @policy_division, url: create_policy_division_path(@division.url_params), html: {class: 'form-inline policyvote'} do |f|
-  %legend.small
-    %p Connect this division with relevant policies.
-    %p Please read policy definitions and the division’s description before altering list.
-  - if @policy_division.errors.any?
-    .alert.alert-danger= @policy_division.errors.full_messages.to_sentence
-  %fieldset
-    %label People who are for
-    = f.select :policy_id, nil, {prompt: "Select related policy"}, size: 1, class: "selectpicker", data: {width: "auto", "live-search" => true} do
-      %optgroup(label="Draft policies")
-        = options_from_collection_for_select(Policy.provisional.order(:name), "id", "name", disabled: @division.policies.map{|p| p.id})
-      %optgroup(label="Published policies")
-        = options_from_collection_for_select(Policy.published.order(:name), "id", "name", disabled: @division.policies.map{|p| p.id})
-    would have
-    %label voted
-    = vote_select(f, nil, prompt: "Select vote")
-  = f.submit 'Connect policy', class: 'btn btn-primary'
+  = simple_form_for @policy_division, url: create_policy_division_path(@division.url_params), html: {class: 'form-inline policyvote'} do |f|
+    %legend.small
+      %p Connect this division with relevant policies.
+      %p Please read policy definitions and the division’s description before altering list.
+    - if @policy_division.errors.any?
+      .alert.alert-danger= @policy_division.errors.full_messages.to_sentence
+    %fieldset
+      %label People who are for
+      = f.select :policy_id, nil, {prompt: "Select related policy"}, size: 1, class: "selectpicker", data: {width: "auto", "live-search" => true} do
+        %optgroup(label="Draft policies")
+          = options_from_collection_for_select(Policy.provisional.order(:name), "id", "name", disabled: @division.policies.map{|p| p.id})
+        %optgroup(label="Published policies")
+          = options_from_collection_for_select(Policy.published.order(:name), "id", "name", disabled: @division.policies.map{|p| p.id})
+      would have
+      %label voted
+      = vote_select(f, nil, prompt: "Select vote")
+    = f.submit 'Connect policy', class: 'btn btn-primary'

--- a/app/views/divisions/show_policies.html.haml
+++ b/app/views/divisions/show_policies.html.haml
@@ -13,8 +13,11 @@
             - if policy_division.policy.provisional?
               %em (draft)
             would have voted
-          = vote_select(f, policy_division.policy.vote_for_division(@division))
-          = f.submit 'Update', class: 'btn btn-primary btn-xs'
+          - if policy(policy_division).update?
+            = vote_select(f, policy_division.policy.vote_for_division(@division))
+            = f.submit 'Update', class: 'btn btn-primary btn-xs'
+          - else
+            = policy_division.policy.vote_for_division(@division)
         - if policy(policy_division).destroy?
           = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy_division.policy_id)), method: :delete, class: 'btn btn-sm btn-link'
 

--- a/app/views/divisions/show_policies.html.haml
+++ b/app/views/divisions/show_policies.html.haml
@@ -15,7 +15,8 @@
             would have voted
           = vote_select(f, policy_division.policy.vote_for_division(@division))
           = f.submit 'Update', class: 'btn btn-primary btn-xs'
-        = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy_division.policy_id)), method: :delete, class: 'btn btn-sm btn-link'
+        - if policy(policy_division).destroy?
+          = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy_division.policy_id)), method: :delete, class: 'btn btn-sm btn-link'
 
 - if policy(@policy_division).create?
   %h3 Make a new connection

--- a/app/views/divisions/show_policies.html.haml
+++ b/app/views/divisions/show_policies.html.haml
@@ -4,18 +4,18 @@
 
 - unless @division.policies.empty?
   %ul.division-policies-list.list-unstyled
-    - @division.policies.order(:name).each do |policy|
+    - @division.policy_divisions.joins(:policy).order(:name).each do |policy_division|
       %li.division-policy
-        = simple_form_for :policy_division, url: update_policy_division_path(@division.url_params.merge(policy_id: policy)), method: :patch, html: {class: 'division-policy-statement form-inline policyvote'} do |f|
+        = simple_form_for :policy_division, url: update_policy_division_path(@division.url_params.merge(policy_id: policy_division.policy_id)), method: :patch, html: {class: 'division-policy-statement form-inline policyvote'} do |f|
           %label.division-policy-statement
             People who are
-            = link_to policy.name_with_for, policy
-            - if policy.provisional?
+            = link_to policy_division.policy.name_with_for, policy_division.policy
+            - if policy_division.policy.provisional?
               %em (draft)
             would have voted
-          = vote_select(f, policy.vote_for_division(@division))
+          = vote_select(f, policy_division.policy.vote_for_division(@division))
           = f.submit 'Update', class: 'btn btn-primary btn-xs'
-        = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy)), method: :delete, class: 'btn btn-sm btn-link'
+        = button_to 'remove', destroy_policy_division_path(@division.url_params.merge(policy_id: policy_division.policy_id)), method: :delete, class: 'btn btn-sm btn-link'
 
 - if policy(@policy_division).create?
   %h3 Make a new connection

--- a/app/views/help/faq/_stance.md
+++ b/app/views/help/faq/_stance.md
@@ -2,7 +2,7 @@ We didn’t. A person’s stance on a [Policy](#policies) is determined by how t
 
 However we might not have the full picture and you can help fix that. Here’s how it works:
 
-1. After [creating a Policy](/policies/new) on <%= inline_project_name %>, we need to find [Divisions](/divisions) that relate to that [Policy](/policies) and work out how someone who supported it would have voted.
+1. After creating a Policy on <%= inline_project_name %>, we need to find [Divisions](/divisions) that relate to that [Policy](/policies) and work out how someone who supported it would have voted.
 
 2. Once a Division is connected to a Policy, <%= inline_project_name %> uses each person’s vote to calculate a where they stand compared to how a supporter would have voted—you can easily see these details and get a technical explanation by clicking through to an individual person on a Policy’s page.
 

--- a/app/views/help/faq/_summaries.md
+++ b/app/views/help/faq/_summaries.md
@@ -1,5 +1,5 @@
 When you click on a link for a [division](/divisions), you will be taken to a summary that
-will either contain an edited description of the division or a message letting you know that we need someone to provide one.
+will either contain an edited description of the division or a message letting you know that one needs to written.
 
 Currently, the divisions with edited summaries are those that are relevant to one of
 the [Policies](/policies). See our [Research](/help/research) page to find out more about how the

--- a/app/views/home/_about.md
+++ b/app/views/home/_about.md
@@ -21,7 +21,13 @@ A huge thank you to [Google Australia](http://www.google.com.au) whose donation 
 
 ### <a name='contribute'></a>You can help
 
-Make this project better for everyone by [summarising divisions](/help/research) and [maintaining and discussing policies](/policies). You can also [make a donation](https://www.oaf.org.au/donate/) to the OpenAustralia&nbsp;Foundation to support us in creating and maintaining projects like this.
+Make this project better for everyone by
+<% if policy(PolicyDivision).new? %>
+  [summarising divisions](/help/research) and [maintaining and discussing policies](/policies).
+<% else %>
+  letting us know about anything that's missing or you think is incorrect.
+<% end %>
+You can also [make a donation](https://www.oaf.org.au/donate/) to the OpenAustralia&nbsp;Foundation to support us in creating and maintaining projects like this.
 
 <%= inline_project_name %> is an Open Source project. That means that a whole community of people add to and help maintain and improve this website in their own big and small ways. The project is hosted on [GitHub](https://github.com/openaustralia/theyvoteforyou), where you can find out how to contribute yourself.
 

--- a/app/views/home/_about.md
+++ b/app/views/home/_about.md
@@ -5,7 +5,10 @@ In Australia, every 3 years or so, we all head to polling places across the coun
 Between elections, how do you know that the individual speaking for you, in your electorate, votes in your interest? Have they ever voted against their party on an issue people like you in your electorate care about? Do they even turn up?
 
 ### How your MP votes on issues you care about
-We’ve peeled back the layers of stuffy jargon, arcane procedures and language so you can find out whether a member voted on [expanding powers to intercept communications](/policies/44) or for [Aboriginal land rights](/policies/24). There is a whole [list of policies](/policies). If you see one missing, you can [add your own](<%= new_policy_path() %>).
+We’ve peeled back the layers of stuffy jargon, arcane procedures and language so you can find out whether a member voted on [expanding powers to intercept communications](/policies/44) or for [Aboriginal land rights](/policies/24). There is a whole [list of policies](/policies).
+<% if policy(PolicyDivision).new? %>
+  If you see one missing, you can [add your own](<%= new_policy_path() %>).
+<% end %>
 
 ### Find your MP
 It’s easy to [get started by searching](/search) or head to the full list of [Representatives](/members/representatives) and  [Senators](/members/senate).

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -45,12 +45,18 @@
 
 .front-panels-block.banner-section
   .container
-    .front-panel.col-md-4
-      = render "panel1"
-    .front-panel.col-md-4
-      = render "panel2"
-    .front-panel.col-md-4
-      = render "panel3"
+    - if policy(PolicyDivision).new?
+      .front-panel.col-md-4
+        = render "panel1"
+      .front-panel.col-md-4
+        = render "panel2"
+      .front-panel.col-md-4
+        = render "panel3"
+    - else
+      .front-panel.col-md-6
+        = render "panel1"
+      .front-panel.col-md-6
+        = render "panel3"
 
 .supporting-orgs-block.banner-section.wide-section
   = render "supporting_orgs"

--- a/app/views/policies/_page_header.html.haml
+++ b/app/views/policies/_page_header.html.haml
@@ -17,8 +17,10 @@
 
 .page-header.row
   %nav.header-actions.col-md-3.col-lg-2
-    = link_to_if policy, "Edit", edit_policy_path(policy), title: "Change title and definition of policy", class: "link-policy-edit btn btn-default btn-xs"
-    = link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
+    - if policy(policy).edit?
+      = link_to_if policy, "Edit", edit_policy_path(policy), title: "Change title and definition of policy", class: "link-policy-edit btn btn-default btn-xs"
+    - if policy(Policy).new?
+      = link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
   %h1.col-md-9.col-lg-10.long-title
     = yield :title
   .lead.policytext.col-md-12

--- a/app/views/policies/drafts.html.haml
+++ b/app/views/policies/drafts.html.haml
@@ -5,7 +5,8 @@
   .section-header.clearfix
     .page-header.container
       %nav.header-actions.col-md-3
-        =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
+        - if policy(Policy).new?
+          =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
       %h1= yield :title
       %p.lead
         Draft policies are those that are not yet complete or consistent enough to display publicly.

--- a/app/views/policies/history.html.haml
+++ b/app/views/policies/history.html.haml
@@ -5,8 +5,10 @@
 
 .page-header.row
   %nav.header-actions.col-md-3
-    =link_to_if(@policy, "Edit", edit_policy_path(@policy), title: "Change title and definition of policy", class: "btn btn-default btn-xs")
-    =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
+    - if policy(@policy).edit?
+      =link_to_if(@policy, "Edit", edit_policy_path(@policy), title: "Change title and definition of policy", class: "btn btn-default btn-xs")
+    - if policy(Policy).new?
+      =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
   -# TODO This title is just a stop-gap. Make it not suck.
   %h1.col-md-9= yield :title
 

--- a/app/views/policies/index.html.haml
+++ b/app/views/policies/index.html.haml
@@ -5,7 +5,8 @@
   .section-header.clearfix
     .page-header.container
       %nav.header-actions.col-md-3
-        =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
+        - if policy(Policy).new?
+          =link_to "New policy", new_policy_path, class: "link-policy-new btn btn-primary btn-xs"
       %h1= yield :title
       %p.lead
         Policies are a group of votes which, taken together, indicate a particular stance on an issue.

--- a/app/views/users/welcome.html.haml
+++ b/app/views/users/welcome.html.haml
@@ -8,22 +8,17 @@
     %p Thanks for creating an account.
 
   %section.page-section
-    - if @policies.empty?
-      %p
-        %strong
-          Why don't you start by #{link_to "creating a policy", new_policy_path}?
-    - else
-      %p.subscriptions-list-intro
-        %strong
-          Get started by subscribing to keep track of changes to the policies that interest you:
+    %p.subscriptions-list-intro
+      %strong
+        Get started by subscribing to keep track of changes to the policies that interest you:
 
-      %ul.subscriptions-list.object-list-compact.list-unstyled
-        - @policies.each do |policy|
-          %li.object-item{id: "policy" + policy.id.to_s}
-            = link_to capitalise_initial_character(policy.name_with_for), policy
-            = button_to watch_policy_path(policy), class: "btn btn-primary btn-sm btn-subscribe", form_class: "object-secondary-inline-sm subscribe-button-form-subscribe" do
-              Subscribe
+    %ul.subscriptions-list.object-list-compact.list-unstyled
+      - @policies.each do |policy|
+        %li.object-item{id: "policy" + policy.id.to_s}
+          = link_to capitalise_initial_character(policy.name_with_for), policy
+          = button_to watch_policy_path(policy), class: "btn btn-primary btn-sm btn-subscribe", form_class: "object-secondary-inline-sm subscribe-button-form-subscribe" do
+            Subscribe
 
-      =link_to "View all policies", policies_path, class: 'btn btn-default btn-sm'
+    =link_to "View all policies", policies_path, class: 'btn btn-default btn-sm'
 
-  %p #{link_to "See recent contributions", history_path}, #{link_to "create a new policy", policies_path} or #{link_to "browse divisions", divisions_path}.
+  %p #{link_to "See recent contributions", history_path} or #{link_to "browse divisions", divisions_path}.

--- a/spec/features/policies_spec.rb
+++ b/spec/features/policies_spec.rb
@@ -11,6 +11,8 @@ describe "Policies", type: :feature do
       fill_in "Email", with: user.email
       fill_in "Password", with: user.password
     end
+    # TODO: Probably better to do this with factory
+    User.first.update!(staff: true)
     click_button "Log in"
     create(:division)
   end

--- a/spec/fixtures/static_pages/.html
+++ b/spec/fixtures/static_pages/.html
@@ -176,7 +176,7 @@ Hey Maze
 </div>
 <div class='front-panels-block banner-section'>
 <div class='container'>
-<div class='front-panel col-md-4'>
+<div class='front-panel col-md-6'>
 <h2>Discover &amp; Share</h2>
 
 <p>Discover how your <a href="/people">representatives in parliament</a> vote on
@@ -184,13 +184,7 @@ Hey Maze
 Share this with others and spread the word.</p>
 
 </div>
-<div class='front-panel col-md-4'>
-<h2>Make it better</h2>
-
-<p>People like you are making votes in Parliament easier to use by <a href="/help/research">summarising divisions</a> and editing <a href="/policies">policies</a>, just like Wikipedia. Fix-up mistakes or add something new—if you see something, do something.</p>
-
-</div>
-<div class='front-panel col-md-4'>
+<div class='front-panel col-md-6'>
 <h2>Use the data</h2>
 
 <p>This is a free and <a href="/help/licencing">open source</a> public resource. Everything here can be reused in your own project. Use <a href="/help/data">our API</a> to remix, play and tell your stories about how they vote to change our laws.</p>

--- a/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
@@ -66,7 +66,7 @@ Submit
 <p class='container'>
 <a title="View the edit history of this division." href="/divisions/representatives/2006-12-06/3/history">Division last edited 15th May 2014</a>
 by
-<a href="/users/1">Henare Degan</a>
+<a href="/users/1">Henare Degan</a> <span class="label label-default staff">staff</span>
 </p>
 </div>
 
@@ -74,7 +74,6 @@ by
 
 <div class='container main-content'><div class='page-header division-header row'>
 <nav class='header-actions col-md-1 col-lg-2'>
-<a title="Change title and summary of this division" class="link-division-edit btn btn-default btn-xs" href="/divisions/representatives/2006-12-06/3/edit">Edit</a>
 </nav>
 <h1 class='division-title col-md-11 col-lg-10 long-title'>
 <small class='pre-title'>6th Dec 2006,  7:29 PM – Representatives</small>
@@ -101,7 +100,6 @@ Bluesky
 
 <section class='motion page-section col-md-8 col-lg-7 motion-edited'>
 <h2 class='motion-title'>Summary</h2>
-<a title="Edit and improve this description" class="link-division-edit division-edit-link btn btn-link btn-xs" href="/divisions/representatives/2006-12-06/3/edit">Edit</a>
 <div class='motion-text'><p>This is some test text. I&#39;d like to illustrate formatting like <em>italics</em> and the following points:</p>
 
 <ul>

--- a/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
@@ -142,7 +142,6 @@ No
 </p>
 </li>
 </ul>
-<a class="small division-related-policies-edit-link" title="Show or change the polices which vote on this division" href="/divisions/representatives/2006-12-06/3/policies">Add or update related policies</a>
 
 </div>
 <p class='division-rebellions-sentence'>

--- a/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
@@ -66,7 +66,7 @@ Submit
 <p class='container'>
 <a title="View the edit history of this division." href="/divisions/representatives/2013-03-14/1/history">Division last edited 20th Oct 2013</a>
 by
-<a href="/users/1">Henare Degan</a>
+<a href="/users/1">Henare Degan</a> <span class="label label-default staff">staff</span>
 </p>
 </div>
 
@@ -74,7 +74,6 @@ by
 
 <div class='container main-content'><div class='page-header division-header row'>
 <nav class='header-actions col-md-1 col-lg-2'>
-<a title="Change title and summary of this division" class="link-division-edit btn btn-default btn-xs" href="/divisions/representatives/2013-03-14/1/edit">Edit</a>
 </nav>
 <h1 class='division-title col-md-11 col-lg-10 long-title'>
 <small class='pre-title'>14th Mar 2013, 10:56 AM – Representatives</small>
@@ -101,7 +100,6 @@ Bluesky
 
 <section class='motion page-section col-md-8 col-lg-7 motion-edited'>
 <h2 class='motion-title'>Summary</h2>
-<a title="Edit and improve this description" class="link-division-edit division-edit-link btn btn-link btn-xs" href="/divisions/representatives/2013-03-14/1/edit">Edit</a>
 <div class='motion-text'><p>This is some test text.</p>
 
 <p>It might relate to bills containing HTML characters like the Carbon Pollution Reduction Scheme Bill 2009 and Bills — National Disability Insurance Scheme Bill</p>

--- a/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
@@ -136,7 +136,6 @@ Yes
 </p>
 </li>
 </ul>
-<a class="small division-related-policies-edit-link" title="Show or change the polices which vote on this division" href="/divisions/representatives/2013-03-14/1/policies">Add or update related policies</a>
 
 </div>
 <p class='division-rebellions-sentence'>

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -83,7 +83,7 @@ Henare Degan
 <p class='container'>
 <a title="View the edit history of this division." href="/divisions/senate/2009-11-25/8/history">Division last edited less than a minute ago</a>
 by
-<a href="/users/1">Henare Degan</a>
+<a href="/users/1">Henare Degan</a> <span class="label label-default staff">staff</span>
 </p>
 </div>
 

--- a/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
@@ -139,7 +139,6 @@ No
 </p>
 </li>
 </ul>
-<a class="small division-related-policies-edit-link" title="Show or change the polices which vote on this division" href="/divisions/senate/2013-03-14/1/policies">Add or update related policies</a>
 
 </div>
 <p class='division-rebellions-sentence'>

--- a/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
@@ -66,7 +66,6 @@ Submit
 
 <div class='container main-content'><div class='page-header division-header row'>
 <nav class='header-actions col-md-1 col-lg-2'>
-<a title="Change title and summary of this division" class="link-division-edit btn btn-default btn-xs" href="/divisions/senate/2013-03-14/1/edit">Edit</a>
 </nav>
 <h1 class='division-title col-md-11 col-lg-10 long-title'>
 <small class='pre-title'>14th Mar 2013 – Senate</small>
@@ -95,7 +94,7 @@ Bluesky
 This division is yet to be summarised. Believe it or not there is no easy to understand explanation of every vote in our parliament.
 If you’d like to know more about this division, reading the
 <a href="https://www.openaustralia.org.au/senate/?id=2013-03-14.22.1">preceding debate</a>
-may be helpful. You can help everybody by improving this resource—<a href="/divisions/senate/2013-03-14/1/edit">provide a summary of what was voted on in this division</a>.
+may be helpful.
 </p>
 
 <nav class='division-external-links page-section'>

--- a/spec/fixtures/static_pages/help/faq.html
+++ b/spec/fixtures/static_pages/help/faq.html
@@ -167,7 +167,7 @@ politicians’ names and how they voted are only recorded in the official record
 
 <h2 id='summaries'>Why don’t all the divisions have edited summaries?</h2>
 <p>When you click on a link for a <a href="/divisions">division</a>, you will be taken to a summary that
-will either contain an edited description of the division or a message letting you know that we need someone to provide one.</p>
+will either contain an edited description of the division or a message letting you know that one needs to written.</p>
 
 <p>Currently, the divisions with edited summaries are those that are relevant to one of
 the <a href="/policies">Policies</a>. See our <a href="/help/research">Research</a> page to find out more about how the
@@ -198,7 +198,7 @@ the only decisions that appear on <em class="project-name">They Vote For You</em
 <p>However we might not have the full picture and you can help fix that. Here’s how it works:</p>
 
 <ol>
-<li><p>After <a href="/policies/new">creating a Policy</a> on <em class="project-name">They Vote For You</em>, we need to find <a href="/divisions">Divisions</a> that relate to that <a href="/policies">Policy</a> and work out how someone who supported it would have voted.</p></li>
+<li><p>After creating a Policy on <em class="project-name">They Vote For You</em>, we need to find <a href="/divisions">Divisions</a> that relate to that <a href="/policies">Policy</a> and work out how someone who supported it would have voted.</p></li>
 <li><p>Once a Division is connected to a Policy, <em class="project-name">They Vote For You</em> uses each person’s vote to calculate a where they stand compared to how a supporter would have voted—you can easily see these details and get a technical explanation by clicking through to an individual person on a Policy’s page.</p></li>
 </ol>
 

--- a/spec/fixtures/static_pages/policies.html
+++ b/spec/fixtures/static_pages/policies.html
@@ -60,7 +60,6 @@ Submit
 <div class='section-header clearfix'>
 <div class='page-header container'>
 <nav class='header-actions col-md-3'>
-<a class="link-policy-new btn btn-primary btn-xs" href="/policies/new">New policy</a>
 </nav>
 <h1>Policies</h1>
 <p class='lead'>

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -69,7 +69,7 @@ Submit
 <p class='container'>
 <a title="View the edit history of this policy." href="/policies/1/history">Policy last edited 1 day ago</a>
 by
-<a href="/users/1">Henare Degan</a>
+<a href="/users/1">Henare Degan</a> <span class="label label-default staff">staff</span>
 </p>
 </div>
 

--- a/spec/fixtures/static_pages/policies/1.html
+++ b/spec/fixtures/static_pages/policies/1.html
@@ -77,8 +77,6 @@ by
 
 <div class='container main-content'><div class='page-header row'>
 <nav class='header-actions col-md-3 col-lg-2'>
-<a title="Change title and definition of policy" class="link-policy-edit btn btn-default btn-xs" href="/policies/1/edit">Edit</a>
-<a class="link-policy-new btn btn-primary btn-xs" href="/policies/new">New policy</a>
 </nav>
 <h1 class='col-md-9 col-lg-10 long-title'>
 Marriage equality

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -77,8 +77,6 @@ by
 
 <div class='container main-content'><div class='page-header row'>
 <nav class='header-actions col-md-3 col-lg-2'>
-<a title="Change title and definition of policy" class="link-policy-edit btn btn-default btn-xs" href="/policies/2/edit">Edit</a>
-<a class="link-policy-new btn btn-primary btn-xs" href="/policies/new">New policy</a>
 </nav>
 <h1 class='col-md-9 col-lg-10 long-title'>
 Offshore processing

--- a/spec/fixtures/static_pages/policies/2.html
+++ b/spec/fixtures/static_pages/policies/2.html
@@ -69,7 +69,7 @@ Submit
 <p class='container'>
 <a title="View the edit history of this policy." href="/policies/2/history">Policy last edited 1 day ago</a>
 by
-<a href="/users/1">Henare Degan</a>
+<a href="/users/1">Henare Degan</a> <span class="label label-default staff">staff</span>
 </p>
 </div>
 

--- a/spec/fixtures_with_factories.rb
+++ b/spec/fixtures_with_factories.rb
@@ -542,7 +542,8 @@ RSpec.shared_context "with fixtures" do
       :confirmed_user,
       id: 1,
       name: "Henare Degan",
-      email: "henare@oaf.org.au"
+      email: "henare@oaf.org.au",
+      staff: true
     )
   end
 


### PR DESCRIPTION
Fixes #1502.  Under the hood this adds pundit policies which control whether the user has the ability to edit divisions, policies and the connections between divisions and policies. In each case if the user doesn't have the ability to do something they should not see it in the interface.

This allows us flexibility in the future to either reinstate the ability of non-staff users to edit things or make more fine-grained decisions about who can do what