### PR TITLE
Remove FUNDING.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-custom: ['https://www.oaf.org.au/donate/']


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
- Removes the FUNDING.yml file from the repository.

## Why was this needed?
- The FUNDING.yml file is obsolete. Funding is now being managed via the [.github](https://github.com/openaustralia/.github/blob/main/.github/FUNDING.yml) repository.

## Implementation/Deploy Steps (Optional)
- Nil required post-merge

## Notes to reviewer (Optional)

