### PR TITLE
Dependabot: Add cooldown period for Bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Default to 7 days

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

