### PR TITLE
Fix broken markdown preview on division edit

### DIFF
--- a/app/assets/javascripts/divisions.js
+++ b/app/assets/javascripts/divisions.js
@@ -3,7 +3,7 @@
 
 $(function() {
   $("form.edit_division a#preview_link").on("shown.bs.tab", function(e) {
-    return $("#preview").html(marked($("#edit textarea").val()));
+    return $("#preview").html(marked.parse($("#edit textarea").val()));
   });
   $(".division-title").widowFix({
     letterLimit: 10,

--- a/spec/features/edit_division_spec.rb
+++ b/spec/features/edit_division_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Editing a division", type: :feature do
+  let(:division) { create(:division, house: "senate") }
+  let(:staff_user) { create(:confirmed_user, staff: true) }
+
+  before do
+    login_as staff_user
+  end
+
+  it "shows a markdown preview of the summary", :js do
+    visit "/divisions/#{division.house}/#{division.date}/#{division.number}/edit"
+    fill_in "newdescription", with: "A **bold** summary"
+    click_on "Preview"
+    expect(page).to have_css("#preview strong", text: "bold")
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.server = :webrick
+
+# Selenium talks to the browser over local HTTP, so these must not be blocked
+WebMock.disable_net_connect!(allow_localhost: true)
+VCR.configure { |c| c.ignore_localhost = true }
+
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers, type: :feature
+
+  config.after(type: :feature) do
+    Warden.test_reset!
+  end
+end


### PR DESCRIPTION
## Description

Fixes the markdown Preview tab on the division edit page, which showed an empty pane when clicked.

The marked-rails upgrade in ee1e6da31 took marked.js from v0.3 to v9. Since marked v5 the global `marked` is a namespace object rather than a callable function, so the tab-shown handler in `app/assets/javascripts/divisions.js` threw `TypeError: marked is not a function` before it could fill the preview pane. Bootstrap still switched tabs, so users just saw nothing. The fix is a one-line change to call `marked.parse()`.

There were no JavaScript-enabled specs, which is why this broke silently. This PR also adds:

- A feature spec that signs in as a staff member, edits a division summary, clicks Preview, and asserts the rendered markdown appears
- The Capybara setup needed to run it: headless Chrome via selenium-webdriver (already in the Gemfile), webrick as the Capybara server, and localhost passthrough for WebMock/VCR so selenium can talk to the browser

## Motivation and Context

Staff need to preview their markdown before submitting division summaries. Resolves #1680.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The new feature spec reproduces the bug: it fails with an empty preview pane against the old code and passes with the fix. Full suite run locally (macOS, Ruby 3.4.4, MySQL 8 in Docker, headless Chrome): 375 examples, 0 failures. Rubocop clean on changed files.

## Screenshots (if appropriate):

See the screenshot in #1680 for the broken behaviour.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: Claude Code/amazon-bedrock/anthropic.claude-fable-5
