### PR TITLE
Return a 404 when a people policy comparison has no distance

### DIFF
--- a/app/controllers/people_distances_controller.rb
+++ b/app/controllers/people_distances_controller.rb
@@ -69,7 +69,13 @@ class PeopleDistancesController < ApplicationController
       return
     end
     # TODO: Preload some associations to speed up queries
-    @person_distance = PeopleDistance.find_by(person1: member1.person, person2: member2.person)
+    # If these two people were never in the same house at the same time then there's
+    # nothing to compare so return a 404
+    @person_distance = PeopleDistance.find_by!(person1: member1.person, person2: member2.person)
+    # If either person has no distance for this policy, for instance because they weren't
+    # in parliament for any of its votes, then return a 404
+    @policy_person_distance1 = PolicyPersonDistance.find_by!(policy: @policy, person: @person_distance.person1)
+    @policy_person_distance2 = PolicyPersonDistance.find_by!(policy: @policy, person: @person_distance.person2)
     # TODO: Probably don't need both @person_distance and people. Refactor to get rid of one
     @people = Person.includes(:members).find([member1.person_id, member2.person_id])
   end

--- a/app/views/people_distances/policy.html.haml
+++ b/app/views/people_distances/policy.html.haml
@@ -10,16 +10,14 @@
 
 .page-header
   .row
-    - ppd1 = PolicyPersonDistance.find_by(policy: @policy, person: @person_distance.person1)
-    - ppd2 = PolicyPersonDistance.find_by(policy: @policy, person: @person_distance.person2)
     .col-sm-6.member-block
       .media= render "member", member: @person_distance.person1.latest_member
-      = link_to member_policy_path_simple(ppd1.person.latest_member, ppd1.policy) do
-        = capitalise_initial_character(policy_agreement_summary(ppd1, with_person: false, with_policy: true))
+      = link_to member_policy_path_simple(@policy_person_distance1.person.latest_member, @policy_person_distance1.policy) do
+        = capitalise_initial_character(policy_agreement_summary(@policy_person_distance1, with_person: false, with_policy: true))
     .col-sm-6.member-block
       .media= render "member", member: @person_distance.person2.latest_member
-      = link_to member_policy_path_simple(ppd2.person.latest_member, ppd2.policy) do
-        = capitalise_initial_character(policy_agreement_summary(ppd2, with_person: false, with_policy: true))
+      = link_to member_policy_path_simple(@policy_person_distance2.person.latest_member, @policy_person_distance2.policy) do
+        = capitalise_initial_character(policy_agreement_summary(@policy_person_distance2, with_person: false, with_policy: true))
 
   .row
     .col-sm-12

--- a/spec/controllers/people_distances_controller_spec.rb
+++ b/spec/controllers/people_distances_controller_spec.rb
@@ -40,4 +40,52 @@ describe PeopleDistancesController, type: :controller do
       end
     end
   end
+
+  describe "#policy" do
+    let(:policy) { create(:policy) }
+    let(:person1) { create(:person) }
+    let(:person2) { create(:person) }
+    let(:request_params) do
+      { house: "representatives", mpc: "clark", mpn: "andrew_wilkie", house2: "representatives", mpc2: "foo", mpn2: "jane_smith", id: policy.id }
+    end
+
+    before do
+      create(:member, person_id: person1.id, first_name: "Andrew", last_name: "Wilkie", house: "representatives", constituency: "Clark")
+      create(:member, person_id: person2.id, first_name: "Jane", last_name: "Smith", house: "representatives", constituency: "Foo")
+    end
+
+    context "when the two people have been compared with each other" do
+      before do
+        create(:people_distance, person1: person1, person2: person2)
+      end
+
+      it "shows the comparison when both people have a distance for the policy" do
+        create(:policy_person_distance, person: person1, policy: policy)
+        create(:policy_person_distance, person: person2, policy: policy)
+
+        get :policy, params: request_params
+
+        expect(response).to have_http_status :ok
+      end
+
+      it "returns a 404 when the first person has no distance for the policy" do
+        create(:policy_person_distance, person: person2, policy: policy)
+
+        expect { get :policy, params: request_params }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "returns a 404 when the second person has no distance for the policy" do
+        create(:policy_person_distance, person: person1, policy: policy)
+
+        expect { get :policy, params: request_params }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    it "returns a 404 when the two people haven't been compared with each other" do
+      create(:policy_person_distance, person: person1, policy: policy)
+      create(:policy_person_distance, person: person2, policy: policy)
+
+      expect { get :policy, params: request_params }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
## Description

`PeopleDistancesController#policy` now looks up both `PolicyPersonDistance` records, and the `PeopleDistance` record, with `find_by!` instead of `find_by`, so a missing record returns a 404 rather than raising in the view. This matches what `MembersController#policy` already does for a member and policy comparison.

The two `PolicyPersonDistance` queries move out of `app/views/people_distances/policy.html.haml` and into the controller, so the view uses `@policy_person_distance1` and `@policy_person_distance2`.

Adds controller specs for the comparison rendering, for each person missing a distance for the policy, and for the two people having no comparison at all.

## Motivation and Context

Fixes #1684. Reported by Sentry as [THEY-VOTE-FOR-YOU-2](https://oaf-org-au.sentry.io/issues/THEY-VOTE-FOR-YOU-2).

Comparing two people on a single policy returned a 500 when one of them had no `PolicyPersonDistance` for that policy:

```
ActionView::Template::Error: undefined method 'person' for nil
app/views/people_distances/policy.html.haml:17
```

`Policy#calculate_person_distances!` only creates those records for the people returned by `people_who_could_have_voted_on_this_policy`, so someone who was not in the relevant house for any of that policy's divisions has no record at all and the view raised `NoMethodError` on `nil`. The URL can be requested directly, so this does not depend on the page being linked from anywhere.

The `PeopleDistance` lookup on the same page has the same shape: two people who never overlapped in the same house have no record, and the view would raise on line 3. That is covered here too.

`PeopleDistancesController#show` still uses `find_by` and is unchanged.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

The specs were written but not run locally: this branch was prepared in an environment with Ruby 3.3.6 against the Gemfile's 3.4.4, no bundled gems and no database, so the suite could not run. All GitHub Actions checks (test and lint) have since passed on this branch, so the pull request has been marked ready for review.

## Screenshots (if appropriate):

n/a

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Written with the assistance of Claude Code (model `claude-opus-5`), reviewed and signed off by me.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NxV5YF4BUudGmkiTy1Sbn1)_
