### PR TITLE
Guard version changeset reads in PoliciesHelper

### DIFF
--- a/app/helpers/policies_helper.rb
+++ b/app/helpers/policies_helper.rb
@@ -125,6 +125,8 @@ module PoliciesHelper
     end
   end
 
+  # Returns nil when the division can't be determined - very old versions may
+  # have neither a changeset nor division_id metadata recorded
   def policy_division_version_division(version)
     id = if version.event == "create"
            # Old versions may not have a changeset recorded so fall back to the
@@ -133,7 +135,7 @@ module PoliciesHelper
          else
            version.reify.division_id
          end
-    Division.find(id)
+    Division.find(id) if id
   end
 
   # This helper is both used in the main application as well as the mailer. Therefore the links
@@ -141,7 +143,11 @@ module PoliciesHelper
   def policy_division_version_sentence(version)
     vote = policy_division_version_vote(version)
     division = policy_division_version_division(version)
-    division_link = content_tag(:em, link_to(division.name, division_url_simple(division)))
+    division_link = if division
+                      content_tag(:em, link_to(division.name, division_url_simple(division)))
+                    else
+                      content_tag(:em, "unknown")
+                    end
     out = []
 
     case version.event
@@ -180,13 +186,15 @@ module PoliciesHelper
     actions = { "create" => "Added", "destroy" => "Removed", "update" => "Changed" }
     vote = policy_division_version_vote_text(version)
     division = policy_division_version_division(version)
+    division_name = division ? division.name : "unknown"
+    division_line = division ? "\n#{division_url_simple(division)}" : ""
 
     case version.event
     when "update"
       if vote
-        "#{actions[version.event]} vote from #{vote} on division #{division.name}.\n#{division_url_simple(division)}"
+        "#{actions[version.event]} vote from #{vote} on division #{division_name}.#{division_line}"
       else
-        "#{actions[version.event]} division #{division.name}.\n#{division_url_simple(division)}"
+        "#{actions[version.event]} division #{division_name}.#{division_line}"
       end
     when "create", "destroy"
       tense = if version.event == "create"
@@ -194,9 +202,9 @@ module PoliciesHelper
               else
                 "was "
               end
-      sentence = "#{actions[version.event]} division #{division.name}."
+      sentence = "#{actions[version.event]} division #{division_name}."
       sentence += " Policy vote #{tense}#{vote}." if vote
-      "#{sentence}\n#{division_url_simple(division)}"
+      "#{sentence}#{division_line}"
     else
       raise
     end

--- a/app/helpers/policies_helper.rb
+++ b/app/helpers/policies_helper.rb
@@ -10,11 +10,12 @@ module PoliciesHelper
 
     case version.event
     when "create"
-      name = version.changeset["name"].second
-      description = version.changeset["description"].second
       result = "Created"
-      result += version.changeset["private"].second == 2 ? " draft " : " "
-      result += "policy #{quote(name)} with description #{quote(description)}."
+      result += version.changeset["private"]&.second == 2 ? " draft " : " "
+      result += "policy"
+      result += " #{quote(version.changeset['name'].second)}" if version.changeset.key?("name")
+      result += " with description #{quote(version.changeset['description'].second)}" if version.changeset.key?("description")
+      result += "."
       changes << result
     when "update"
       if version.changeset.key?("name")
@@ -49,11 +50,11 @@ module PoliciesHelper
   def policy_version_sentence_text(version)
     case version.event
     when "create"
-      name = version.changeset["name"].second
-      description = version.changeset["description"].second
       result = "Created"
-      result += version.changeset["private"].second == 2 ? " draft " : " "
-      result += "policy #{quote(name)} with description #{quote(description)}"
+      result += version.changeset["private"]&.second == 2 ? " draft " : " "
+      result += "policy"
+      result += " #{quote(version.changeset['name'].second)}" if version.changeset.key?("name")
+      result += " with description #{quote(version.changeset['description'].second)}" if version.changeset.key?("description")
       result += "."
     when "update"
       changes = []
@@ -90,33 +91,48 @@ module PoliciesHelper
     result
   end
 
+  # Returns nil when the version's changeset doesn't record the vote (e.g. old
+  # versions with no object_changes, or updates that changed something else)
   def policy_division_version_vote(version)
     case version.event
     when "create"
-      policy_vote_display_with_class(version.changeset["vote"].second)
+      vote = version.changeset["vote"]&.second
+      policy_vote_display_with_class(vote) if vote
     when "destroy"
       policy_vote_display_with_class(version.reify.vote)
     when "update"
-      text = policy_vote_display_with_class(version.changeset["vote"].first)
+      votes = version.changeset["vote"]
+      return if votes.nil?
+
+      text = policy_vote_display_with_class(votes.first)
       text += " to ".html_safe
-      text += policy_vote_display_with_class(version.changeset["vote"].second)
+      text += policy_vote_display_with_class(votes.second)
       text
     end
   end
 
+  # Returns nil when the version's changeset doesn't record the vote (see above)
   def policy_division_version_vote_text(version)
     case version.event
     when "create"
-      vote_display(version.changeset["vote"].second)
+      vote = version.changeset["vote"]&.second
+      vote_display(vote) if vote
     when "destroy"
       vote_display(version.reify.vote)
     when "update"
-      "#{vote_display(version.changeset['vote'].first)} to #{vote_display(version.changeset['vote'].second)}"
+      votes = version.changeset["vote"]
+      "#{vote_display(votes.first)} to #{vote_display(votes.second)}" if votes
     end
   end
 
   def policy_division_version_division(version)
-    id = version.event == "create" ? version.changeset["division_id"].second : version.reify.division_id
+    id = if version.event == "create"
+           # Old versions may not have a changeset recorded so fall back to the
+           # division_id metadata stored on the version itself
+           version.changeset["division_id"]&.second || version.division_id
+         else
+           version.reify.division_id
+         end
     Division.find(id)
   end
 
@@ -130,16 +146,22 @@ module PoliciesHelper
 
     case version.event
     when "update"
-      out << "Changed vote from "
-      out << vote
-      out << " on division "
+      if vote
+        out << "Changed vote from "
+        out << vote
+        out << " on division "
+      else
+        out << "Changed division "
+      end
       out << division_link
     when "create"
       out = []
       out << "Added division "
       out << division_link
-      out << ". Policy vote set to "
-      out << vote
+      if vote
+        out << ". Policy vote set to "
+        out << vote
+      end
     when "destroy"
       out = []
       out << "Removed division "
@@ -161,14 +183,20 @@ module PoliciesHelper
 
     case version.event
     when "update"
-      "#{actions[version.event]} vote from #{vote} on division #{division.name}.\n#{division_url_simple(division)}"
+      if vote
+        "#{actions[version.event]} vote from #{vote} on division #{division.name}.\n#{division_url_simple(division)}"
+      else
+        "#{actions[version.event]} division #{division.name}.\n#{division_url_simple(division)}"
+      end
     when "create", "destroy"
       tense = if version.event == "create"
                 "set to "
               else
                 "was "
               end
-      "#{actions[version.event]} division #{division.name}. Policy vote #{tense}#{vote}.\n#{division_url_simple(division)}"
+      sentence = "#{actions[version.event]} division #{division.name}."
+      sentence += " Policy vote #{tense}#{vote}." if vote
+      "#{sentence}\n#{division_url_simple(division)}"
     else
       raise
     end

--- a/spec/helpers/policies_helper_spec.rb
+++ b/spec/helpers/policies_helper_spec.rb
@@ -24,6 +24,14 @@ describe PoliciesHelper, type: :helper do
       it { expect(helper.version_sentence(version)).to be_html_safe }
     end
 
+    context "with create policy where the changeset was not recorded" do
+      let(:version) { instance_double(PaperTrail::Version, item_type: "Policy", event: "create", changeset: {}) }
+
+      it { expect(helper.version_sentence(version)).to eq '<p class="change-action">Created policy.</p>' }
+      it { expect(helper.version_sentence_text(version)).to eq "Created policy." }
+      it { expect(helper.version_sentence(version)).to be_html_safe }
+    end
+
     context "with change name on policy" do
       let(:version) { instance_double(PaperTrail::Version, item_type: "Policy", event: "update", whodunnit: 1, created_at: 1.hour.ago, changeset: { "name" => ["Version A", "Version B"] }, reify: mock_model(Policy, id: 3, name: "Version A")) }
 
@@ -85,11 +93,27 @@ describe PoliciesHelper, type: :helper do
         it { expect(helper.version_sentence(version)).to be_html_safe }
       end
 
+      context "with create vote on policy where the changeset was not recorded" do
+        let(:version) { instance_double(PaperTrail::Version, item_type: "PolicyDivision", event: "create", whodunnit: 1, created_at: 1.hour.ago, changeset: {}, division_id: 5, policy_id: 3) }
+
+        it { expect(helper.version_sentence(version)).to eq '<p class="change-action">Added division <em><a href="http://test.host/divisions/representatives/2001-01-01/2">blah</a></em>.</p>' }
+        it { expect(helper.version_sentence_text(version)).to eq "Added division blah.\nhttp://test.host/divisions/representatives/2001-01-01/2" }
+        it { expect(helper.version_sentence(version)).to be_html_safe }
+      end
+
       context "with change vote on policy" do
         let(:version) { instance_double(PaperTrail::Version, item_type: "PolicyDivision", event: "update", whodunnit: 1, created_at: 1.hour.ago, changeset: { "vote" => %w[no aye] }, reify: instance_double(PolicyDivision, division_id: 5), policy_id: 3) }
 
         it { expect(helper.version_sentence(version)).to eq '<p class="change-action">Changed vote from <span class="division-policy-statement-vote voted-no">No</span> to <span class="division-policy-statement-vote voted-aye">Yes</span> on division <em><a href="http://test.host/divisions/representatives/2001-01-01/2">blah</a></em>.</p>' }
         it { expect(helper.version_sentence_text(version)).to eq "Changed vote from No to Yes on division blah.\nhttp://test.host/divisions/representatives/2001-01-01/2" }
+        it { expect(helper.version_sentence(version)).to be_html_safe }
+      end
+
+      context "with update to policy division that did not change the vote" do
+        let(:version) { instance_double(PaperTrail::Version, item_type: "PolicyDivision", event: "update", whodunnit: 1, created_at: 1.hour.ago, changeset: {}, reify: instance_double(PolicyDivision, division_id: 5), policy_id: 3) }
+
+        it { expect(helper.version_sentence(version)).to eq '<p class="change-action">Changed division <em><a href="http://test.host/divisions/representatives/2001-01-01/2">blah</a></em>.</p>' }
+        it { expect(helper.version_sentence_text(version)).to eq "Changed division blah.\nhttp://test.host/divisions/representatives/2001-01-01/2" }
         it { expect(helper.version_sentence(version)).to be_html_safe }
       end
     end

--- a/spec/helpers/policies_helper_spec.rb
+++ b/spec/helpers/policies_helper_spec.rb
@@ -101,6 +101,14 @@ describe PoliciesHelper, type: :helper do
         it { expect(helper.version_sentence(version)).to be_html_safe }
       end
 
+      context "with create vote on policy where neither the changeset nor the division id were recorded" do
+        let(:version) { instance_double(PaperTrail::Version, item_type: "PolicyDivision", event: "create", whodunnit: 1, created_at: 1.hour.ago, changeset: {}, division_id: nil, policy_id: 3) }
+
+        it { expect(helper.version_sentence(version)).to eq '<p class="change-action">Added division <em>unknown</em>.</p>' }
+        it { expect(helper.version_sentence_text(version)).to eq "Added division unknown." }
+        it { expect(helper.version_sentence(version)).to be_html_safe }
+      end
+
       context "with change vote on policy" do
         let(:version) { instance_double(PaperTrail::Version, item_type: "PolicyDivision", event: "update", whodunnit: 1, created_at: 1.hour.ago, changeset: { "vote" => %w[no aye] }, reify: instance_double(PolicyDivision, division_id: 5), policy_id: 3) }
 


### PR DESCRIPTION
## Description

Fixes a `NoMethodError` (`undefined method 'first'/'second' for nil`) raised while rendering policy history entries, which was 500ing the policy history, user profile and home history pages.

PaperTrail's `changeset` only contains the attributes that actually changed, and is empty entirely for old versions where `object_changes` was never recorded (the column is nullable). `PoliciesHelper` read changeset values unguarded in several places, so:

- a `PolicyDivision` **update** that didn't touch the vote crashed on `changeset["vote"].first`
- a **create** version with no recorded changeset crashed on `changeset["vote"].second`

This PR guards every changeset read in the helper and renders a degraded-but-sensible history sentence when the changeset has nothing to say ("Added division X." / "Changed division X." / "Created policy."). It also:

- fixes the identical unguarded pattern in the `_text` helper variants used by the policy-update alert mailer
- fixes the same failure mode in the `Policy` create sentence (`name`/`description`/`private` reads)
- falls back to the `division_id` metadata stored on the version row when a create version's changeset can't supply the division — without this, fixing the vote read would just move the crash one line down

Deliberately **not** included: a blanket per-version `rescue` in the `_history_list` partial (option 2 in the issue triage). The guards fix every observed failure, and a blanket rescue would hide future bugs.

## Motivation and Context

Resolves #1627 — "NoMethodError in policies # history occurs 60 times a day".

Closes the five Sentry issues tracked there (all landing in `app/helpers/policies_helper.rb:96`):

Fixes THEY-VOTE-FOR-YOU-3
Fixes THEY-VOTE-FOR-YOU-4
Fixes THEY-VOTE-FOR-YOU-5
Fixes THEY-VOTE-FOR-YOU-6
Fixes THEY-VOTE-FOR-YOU-7

Root cause was verified against the recorded Sentry events: the release SHA on the events (`41ede2358`) is an ancestor of this branch, and the stack traces confirm both the `PoliciesController#history` and `UsersController#show` paths crash in the same helper frame.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Added 9 new helper specs that reproduce the production failures with synthetic data (an update whose changeset lacks `"vote"`, a create with an empty changeset, and the Policy-create equivalent) — all failed with the exact `NoMethodError` before the fix and pass after. Full RSpec suite run locally against MySQL 8 in Docker mirroring CI: 384 examples, 0 failures. RuboCop clean on the changed files.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: this change was produced with AI assistance (`Assisted-by: Claude Code:amazon-bedrock/anthropic.claude-fable-5`), reviewed and signed off by a human.