### PR TITLE
Enable Sentry session replay and tracing in JS

### DIFF
--- a/app/views/application/_sentry_javascript.html.haml
+++ b/app/views/application/_sentry_javascript.html.haml
@@ -1,12 +1,20 @@
 - if (dsn = Rails.application.credentials.dig(:sentry, :dsn))
   -# The Loader Script key is the public key from the DSN
   - public_key = URI.parse(dsn).user
-  = javascript_include_tag "https://js.sentry-cdn.com/#{public_key}.min.js", crossorigin: "anonymous"
   -# Pick up the release detected by the backend Sentry SDK so frontend and backend events match
   - release = defined?(Sentry) && Sentry.respond_to?(:configuration) && Sentry.configuration&.release
+  -# window.sentryOnLoad must be defined before the Loader Script tag so the
+  -# lazy-loaded SDK picks up our configuration when it initialises
   :javascript
-    Sentry.onLoad(function() {
+    window.sentryOnLoad = function () {
       Sentry.init({
-        environment: '#{j Rails.env}'#{", release: '#{j release}'" if release}
+        environment: '#{j Rails.env}'#{", release: '#{j release}'" if release},
+        // Sample 10% of pageloads/navigations for browser tracing
+        tracesSampleRate: 0.1,
+        // Only record session replays when an error occurs, with default
+        // privacy masking (maskAllText/blockAllMedia) left enabled
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 1.0
       });
-    });
+    };
+  = javascript_include_tag "https://js.sentry-cdn.com/#{public_key}.min.js", crossorigin: "anonymous"


### PR DESCRIPTION
## Description

Configures the frontend Sentry Loader Script with:

- **Browser tracing** at `tracesSampleRate: 0.1` (matching the backend sample rate)
- **Session Replay, errors-only**: `replaysSessionSampleRate: 0`, `replaysOnErrorSampleRate: 1.0` — replays are recorded only when an error occurs
- Default privacy masking (`maskAllText`/`blockAllMedia`) left enabled, matching the backend's `send_default_pii = false` stance

The config now uses the documented `window.sentryOnLoad` pattern, defined before the loader script tag. Existing environment/release/DSN wiring is preserved unchanged.

**Note for deploy:** the Loader Script config in Sentry project settings (Settings → Client Keys → Configure) must have the **Performance** and **Session Replay** toggles enabled, otherwise the lazy-loaded bundle won't include these features.

## Motivation and Context

Part of #1607 — replacing Honeybadger with Sentry. Adds frontend performance visibility and error replays to aid debugging.
* #1607

## How Has This Been Tested?

- [x] Ran automated tests on my own system — Haml parse check on the changed partial, standalone render check producing the expected JS, `node --check` on the generated JS, and `bundle exec rubocop` (167 files, no offenses)
- [ ] Confirmed it passed the GitHub actions tests

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

**AI assistance disclosure:** this change was written with AI assistance (OpenCode, model `amazon-bedrock/anthropic.claude-fable-5`), as disclosed in the commit trailer. Reviewed and signed off by a human.
