### PR TITLE
Ignore in-app browser autofill noise in Sentry JS

### DIFF
--- a/app/views/application/_sentry_javascript.html.haml
+++ b/app/views/application/_sentry_javascript.html.haml
@@ -9,6 +9,10 @@
     window.sentryOnLoad = function () {
       Sentry.init({
         environment: '#{j Rails.env}'#{", release: '#{j release}'" if release},
+        // Drop errors injected into the page by in-app browsers (e.g. the
+        // Facebook/Instagram iOS autofill bridge) - they aren't our code.
+        // See https://github.com/openaustralia/theyvoteforyou/issues/1690
+        ignoreErrors: ['_AutofillCallbackHandler'],
         // Sample 10% of pageloads/navigations for browser tracing
         tracesSampleRate: 0.1,
         // Only record session replays when an error occurs, with default

--- a/spec/views/application/_sentry_javascript_spec.rb
+++ b/spec/views/application/_sentry_javascript_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "application/_sentry_javascript", type: :view do
+  context "when a sentry dsn is configured" do
+    before do
+      allow(Rails.application.credentials).to receive(:dig)
+        .with(:sentry, :dsn)
+        .and_return("https://examplepublickey@o0.ingest.sentry.io/0")
+      render
+    end
+
+    it "defines the configuration before the loader script so a blocked loader can't raise ReferenceError" do
+      expect(rendered.index("window.sentryOnLoad")).to be < rendered.index("js.sentry-cdn.com")
+    end
+
+    it "ignores errors injected by in-app browsers" do
+      expect(rendered).to include("_AutofillCallbackHandler")
+    end
+  end
+
+  context "when no sentry dsn is configured" do
+    it "renders nothing" do
+      allow(Rails.application.credentials).to receive(:dig)
+        .with(:sentry, :dsn)
+        .and_return(nil)
+      render
+      expect(rendered).to be_blank
+    end
+  end
+end

--- a/spec/views/application/_sentry_javascript_spec.rb
+++ b/spec/views/application/_sentry_javascript_spec.rb
@@ -8,6 +8,7 @@ describe "application/_sentry_javascript", type: :view do
       allow(Rails.application.credentials).to receive(:dig)
         .with(:sentry, :dsn)
         .and_return("https://examplepublickey@o0.ingest.sentry.io/0")
+      allow(view).to receive(:user_signed_in?).and_return(false)
       render
     end
 


### PR DESCRIPTION
## Description

Adds `ignoreErrors: ['_AutofillCallbackHandler']` to the browser Sentry configuration so errors injected by the Facebook/Instagram iOS in-app browser's autofill bridge are dropped client-side, and adds a view spec for the Sentry JS partial that also locks in the config-before-loader-script ordering from #1688.

## Motivation and Context

Honeybadger fault [84745896](https://app.honeybadger.io/projects/37542/faults/84745896) (see #1690) is a bucket of client-side `ReferenceError`s with two sources:

1. **`Sentry is not defined`** — the old Loader Script setup called `Sentry.onLoad(...)` inline *after* the CDN script tag, which throws whenever the loader is blocked (ad blockers, privacy browsers, crawlers like Facebook's `meta-webindexer`). Already fixed on `main` by #1688 and reporting removed with Honeybadger in #1689 — production just hasn't been redeployed since (still on `e4db521`). The new spec guards against reintroducing that ordering.
2. **`Can't find variable: _AutofillCallbackHandler`** — 64% of the fault's notices in the last 30 days. It's noise from Facebook/Instagram's in-app browser, not our code. Once Honeybadger is gone, Sentry becomes the browser error reporter and would ingest all of it — and record a session replay for every occurrence via `replaysOnErrorSampleRate: 1.0`. This change drops it before it's sent.

Resolves #1690

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system

New view spec plus the home controller request specs (which render the layout and this partial) pass locally against a MySQL 8.0 container: `bundle exec rspec spec/views/application/_sentry_javascript_spec.rb spec/requests/home_controller_spec.rb`

- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
