### PR TITLE
Retry card screenshots and skip failing urls

### DIFF
--- a/app/lib/card_screenshotter/screenshot_error.rb
+++ b/app/lib/card_screenshotter/screenshot_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CardScreenshotter
+  # Raised when taking a screenshot of a card page fails. The original error
+  # (e.g. Net::ReadTimeout) is available via #cause
+  class ScreenshotError < StandardError; end
+end

--- a/app/lib/card_screenshotter/utils.rb
+++ b/app/lib/card_screenshotter/utils.rb
@@ -5,6 +5,9 @@ module CardScreenshotter
     CARD_WIDTH = 1200
     CARD_HEIGHT = 628
     RESTART_BROWSER_AFTER_NUMBER_OF_REQUESTS = 50
+    # Transient errors (e.g. Net::ReadTimeout) get this many attempts, with a
+    # browser restart in between, before the url is reported and skipped
+    MAX_SCREENSHOT_ATTEMPTS = 3
 
     attr_reader :driver
 
@@ -41,7 +44,20 @@ module CardScreenshotter
         restart_browser!
         @count = 0
       end
-      screenshot_and_save_without_restart(url, path)
+      attempts = 0
+      begin
+        attempts += 1
+        screenshot_and_save_without_restart(url, path)
+      rescue ScreenshotError => e
+        if attempts < MAX_SCREENSHOT_ATTEMPTS
+          # A timeout can leave the browser session wedged, so start fresh
+          restart_browser!
+          retry
+        end
+        # Report and move on so one bad url doesn't abort the whole run
+        Rails.logger.warn(e.message)
+        Sentry.capture_exception(e) if defined?(Sentry) && Sentry.initialized?
+      end
       @count += 1
     end
 
@@ -54,8 +70,9 @@ module CardScreenshotter
       driver.get(url)
       driver.screenshot_as(:png)
     rescue StandardError => e
-      # Make the error a little more useful by including the failing url
-      raise "Error #{e} while screenshotting url: #{url}"
+      # Include the failing url in the message. The original error is
+      # preserved as the cause of the new exception
+      raise ScreenshotError, "Error #{e} while screenshotting url: #{url}"
     end
 
     def save_image(image, path)

--- a/spec/lib/card_screenshotter/utils_spec.rb
+++ b/spec/lib/card_screenshotter/utils_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe CardScreenshotter::Utils do
+  subject(:screenshotter) { described_class.new }
+
+  let(:driver) { instance_double(Selenium::WebDriver::Driver) }
+
+  before do
+    allow(Selenium::WebDriver).to receive(:for).and_return(driver)
+    allow(driver).to receive(:execute_script).and_return(
+      [described_class::CARD_WIDTH, described_class::CARD_HEIGHT, described_class::CARD_WIDTH,
+       described_class::CARD_HEIGHT]
+    )
+    allow(driver).to receive(:quit)
+  end
+
+  describe "#screenshot" do
+    it "wraps errors in ScreenshotError, keeping the url in the message and the original error as the cause" do
+      allow(driver).to receive(:get).and_raise(Net::ReadTimeout)
+
+      expect { screenshotter.screenshot("https://example.com/foo?card=true") }.to raise_error(
+        CardScreenshotter::ScreenshotError, %r{https://example\.com/foo\?card=true}
+      ) do |error|
+        expect(error.cause).to be_a(Net::ReadTimeout)
+      end
+    end
+  end
+
+  describe "#screenshot_and_save" do
+    let(:path) { Rails.root.join("tmp/test_cards/example.png").to_s }
+
+    after { FileUtils.rm_rf(Rails.root.join("tmp/test_cards")) }
+
+    it "saves the screenshot" do
+      allow(driver).to receive(:get)
+      allow(driver).to receive(:screenshot_as).with(:png).and_return("png data")
+
+      screenshotter.screenshot_and_save("https://example.com", path)
+
+      expect(File.read(path)).to eq "png data"
+    end
+
+    it "retries with a fresh browser after a transient failure" do
+      attempts = 0
+      allow(driver).to receive(:get) do
+        attempts += 1
+        raise Net::ReadTimeout if attempts == 1
+      end
+      allow(driver).to receive(:screenshot_as).with(:png).and_return("png data")
+
+      screenshotter.screenshot_and_save("https://example.com", path)
+
+      # The browser is restarted between attempts to clear any wedged state
+      expect(driver).to have_received(:quit).once
+      expect(File.read(path)).to eq "png data"
+    end
+
+    it "reports to Sentry and skips the url once retries are exhausted so the batch can continue" do
+      allow(driver).to receive(:get).and_raise(Net::ReadTimeout)
+      allow(Sentry).to receive(:initialized?).and_return(true)
+      allow(Sentry).to receive(:capture_exception)
+
+      expect { screenshotter.screenshot_and_save("https://example.com", path) }.not_to raise_error
+
+      expect(Sentry).to have_received(:capture_exception).with(instance_of(CardScreenshotter::ScreenshotError))
+      expect(File.exist?(path)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Description

Makes the nightly card screenshotting resilient to transient page-load timeouts:

- `CardScreenshotter::Utils#screenshot` now raises a new `CardScreenshotter::ScreenshotError` (instead of a bare `RuntimeError` string), keeping the failing URL in the message while preserving the original exception (e.g. `Net::ReadTimeout`) as `#cause`.
- `#screenshot_and_save` retries a failing URL up to 3 attempts, restarting the headless Chrome browser between attempts since a timeout can leave the session wedged.
- If a URL still fails after retries, it is reported to Sentry (`Sentry.capture_exception`) and logged, then skipped — so one flaky page no longer aborts the entire night's card generation run (which also leaked the browser process, as `close_driver!` was never reached).
- Adds a spec for `CardScreenshotter::Utils` covering the wrap/retry/report-and-skip behaviour (there was previously no coverage of this class).

## Motivation and Context

Resolves #1691 — the nightly cron (`rake application:cron:nightly`) has failed 44 times since Feb 2026 with `RuntimeError: Error Net::ReadTimeout while screenshotting url: ...`, a different person/policy URL each time ([Honeybadger fault](https://app.honeybadger.io/projects/37542/faults/127759645)). Each failure killed the remainder of that night's screenshot batch.

The investigation also explains why this error appeared in Honeybadger but never in Sentry: the failing production deploy (`e4db521`) still ran both reporters. Sentry's rake integration captured the exception, but the event sits on the SDK's background worker queue and rake exits immediately afterwards — Sentry's `at_exit` handler waits only 1 second (`Sentry::BackgroundWorker#shutdown_timeout`) for the queue to drain. The earlier-queued `:error` cron check-in got through (Sentry issue THEY-VOTE-FOR-YOU-8, "Cron failure: application-cron-nightly"), but the error event was dropped at process exit. Honeybadger reports synchronously, so it kept the error. With this change the exception is reported mid-run via `Sentry.capture_exception`, long before process exit, so delivery no longer races shutdown (and Sentry's captured-exception marker prevents any duplicate from the rake integration).

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system

Ran the new spec plus the full suite locally against a MySQL 8 container mirroring CI (`bundle exec rspec` — 395 examples, 0 failures) and `bundle exec rubocop` on the changed files (no offences). The retry/skip behaviour is exercised by the new specs with a stubbed Selenium driver; no real browser or manual production run was performed.

- [x] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

AI disclosure: prepared with OpenCode using model anthropic.claude-fable-5 (`Assisted-by: OpenCode:anthropic.claude-fable-5` trailer on the commit); reviewed by @benrfairless.

