### PR TITLE
Fix crash on password reset pages

### DIFF
--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -3,7 +3,7 @@
 %h2= yield :title
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/error_messages", resource: resource
   = f.hidden_field :reset_password_token
   .form-group
     = f.label :password, "New password"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -6,7 +6,7 @@
   %p Enter your email and we’ll send you instructions to reset your password
 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-    = devise_error_messages!
+    = render "devise/shared/error_messages", resource: resource
     .form-group
       = f.label :email
       = f.email_field :email, autofocus: true, class: "form-control", required: "required"

--- a/spec/requests/devise/passwords_controller_spec.rb
+++ b/spec/requests/devise/passwords_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Devise::PasswordsController, type: :request do
+  describe "GET /users/password/new" do
+    it "renders the forgotten password form" do
+      get "/users/password/new"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /users/password" do
+    it "re-renders the form with validation errors when the email is blank" do
+      post "/users/password", params: { user: { email: "" } }
+      expect(response.body).to include("Email can&#39;t be blank")
+    end
+  end
+
+  describe "GET /users/password/edit" do
+    it "renders the change password form" do
+      get "/users/password/edit", params: { reset_password_token: "abc123" }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Replaces the removed `devise_error_messages!` helper with the `devise/shared/error_messages` partial (the replacement Devise ships) in the two password reset views:

- `app/views/devise/passwords/new.html.haml` ("Forgot your password?" form)
- `app/views/devise/passwords/edit.html.haml` (change-password form reached from a reset email)

Also adds request specs covering both views.

## Motivation and Context

The password reset pages raise a 500 error in production. `devise_error_messages!` was deprecated in Devise 4.6 and has since been removed, so both views crash with `NoMethodError` under the Devise 5.0.4 we now run.

Resolves #1694 (Sentry issue [THEY-VOTE-FOR-YOU-9](https://oaf-org-au.sentry.io/issues/140923201/?referrer=github_integration))

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

New request specs at `spec/requests/devise/passwords_controller_spec.rb` cover:

- `GET /users/password/new` renders successfully
- `POST /users/password` with a blank email re-renders the form and displays the validation error
- `GET /users/password/edit` renders successfully

All three failed with the `NoMethodError` from the Sentry report before the fix and pass after it (run locally against MySQL 8, matching the CI setup).

## Screenshots (if appropriate):

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


## AI assistance

This change was produced with AI assistance: Claude Code:amazon-bedrock/anthropic.claude-fable-5 (disclosed per the org [contributing guidelines](https://github.com/openaustralia/.github/blob/main/CONTRIBUTING.md)). The commit carries matching `Assisted-by` and `Signed-off-by` trailers.

_Note: replaces #1695, which GitHub closed when the head branch was renamed to follow the Conventional Branch naming convention._
