### PR TITLE
Build division caches as divisions are loaded

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -76,7 +76,7 @@ class DivisionsController < ApplicationController
     if @division.nil?
       render "home/error404", status: :not_found
     else
-      @rebellions = @division.votes.rebellious.order("members.last_name", "members.first_name") if @division.rebellions.positive?
+      @rebellions = @division.votes.rebellious.order("members.last_name", "members.first_name") if @division.rebellions.to_i.positive?
       @whips = @division.whips.order(:party)
       @votes = @division.votes.joins(:member).includes(:member).order("members.party", "vote", "members.last_name", "members.first_name")
 

--- a/app/helpers/divisions_helper.rb
+++ b/app/helpers/divisions_helper.rb
@@ -64,6 +64,8 @@ module DivisionsHelper
   end
 
   def majority_strength_in_words(division)
+    return "" unless division.outcome_known?
+
     if division.unanimous?
       "unanimously"
     elsif division.tied?
@@ -94,10 +96,14 @@ module DivisionsHelper
 
   # TODO: We should be taking into account the strange rules about tied votes in the Senate
   def division_outcome(division)
+    return "Unknown" unless division.outcome_known?
+
     division.passed? ? "Passed" : "Not passed"
   end
 
   def division_outcome_class(division)
+    return "division-outcome-unknown" unless division.outcome_known?
+
     division.passed? ? "division-outcome-passed" : "division-outcome-not-passed"
   end
 

--- a/app/lib/data_loader/debates.rb
+++ b/app/lib/data_loader/debates.rb
@@ -53,6 +53,12 @@ module DataLoader
 
                 Vote.create!(division: division, member: member, vote: vote[0], teller: vote[1])
               end
+
+              # Build the caches the division pages read from before we commit, so
+              # the division is never visible without them. Whips first - the
+              # rebellion counts in DivisionInfo are derived from them.
+              Whip.update_divisions!(division.id)
+              DivisionInfo.update_divisions!(division.id)
             end
           end
         end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -15,7 +15,7 @@ class Division < ApplicationRecord
   has_many :wiki_motions, -> { order(created_at: :desc) }, inverse_of: :division, dependent: :destroy
   has_and_belongs_to_many :bills
 
-  delegate :turnout, :aye_majority, :rebellions, :majority, :majority_fraction, to: :division_info
+  delegate :turnout, :aye_majority, :rebellions, :majority, :majority_fraction, to: :division_info, allow_nil: true
 
   scope :in_date_range, ->(date_start, date_end) { where(date: date_start...date_end) }
   scope :in_house, ->(house) { where(house: house) }
@@ -77,19 +77,33 @@ class Division < ApplicationRecord
     end
   end
 
+  # These three fall back to false when the division_info cache hasn't been built
+  # yet, so a missing cache degrades instead of raising. False therefore means
+  # "no, or we don't know yet" - check outcome_known? before displaying it.
   def passed?
+    return false if aye_majority.nil?
+
     tied? ? false : aye_majority >= 1
   end
 
   # Equal number of votes for the ayes and noes
   def tied?
+    return false if aye_majority.nil?
+
     aye_majority.zero?
   end
 
   # Did everyone vote the same way?
   # TODO: Move this to division_info and delegate
   def unanimous?
+    return false if turnout.nil?
+
     turnout.positive? && majority == turnout
+  end
+
+  # Has the division_info cache been built for this division yet?
+  def outcome_known?
+    !division_info.nil?
   end
 
   # Using whips cache to calculate this. Is this the best way?
@@ -111,7 +125,7 @@ class Division < ApplicationRecord
   end
 
   def total_votes
-    division_info.turnout
+    division_info&.turnout
   end
 
   def aye_votes_including_tells
@@ -123,12 +137,12 @@ class Division < ApplicationRecord
   end
 
   def possible_votes
-    division_info.possible_turnout
+    division_info&.possible_turnout
   end
 
   # Returns nil if otherwise we would get divide by zero
   def attendance_fraction
-    total_votes.to_f / possible_votes if possible_votes.positive?
+    total_votes.to_f / possible_votes if possible_votes.to_i.positive?
   end
 
   def edited?

--- a/app/models/division_info.rb
+++ b/app/models/division_info.rb
@@ -15,43 +15,55 @@ class DivisionInfo < ApplicationRecord
   end
 
   def self.update_all!
-    rebellions = all_rebellion_counts
-    tells = all_tells_counts
-    turnout = all_turnout_counts
-    possible_turnout = all_possible_turnout_counts
-    aye_majority = all_aye_majority_counts
+    update_divisions!(nil)
+  end
 
-    Division.ids.each do |id|
+  # Rebuild the cache for just these divisions, or for all of them when given
+  # nil. Whips must already exist for them, otherwise the rebellion counts come
+  # back empty - Vote.rebellious inner joins whips.
+  def self.update_divisions!(division_ids)
+    division_ids = Array(division_ids) if division_ids
+    return if division_ids && division_ids.empty?
+
+    rebellions = all_rebellion_counts(division_ids)
+    tells = all_tells_counts(division_ids)
+    turnout = all_turnout_counts(division_ids)
+    possible_turnout = all_possible_turnout_counts(division_ids)
+    aye_majority = all_aye_majority_counts(division_ids)
+
+    # Divisions with no votes at all are missing from every aggregate above, but
+    # still need a row of zeroes, so drive the loop from the ids not the counts.
+    (division_ids || Division.ids).each do |id|
       info = DivisionInfo.find_or_initialize_by(division_id: id)
-      info.update(rebellions: rebellions[id] || 0, tells: tells[id] || 0,
-                  turnout: turnout[id] || 0, possible_turnout: possible_turnout[id] || 0,
-                  aye_majority: aye_majority[id] || 0)
+      info.update!(rebellions: rebellions[id] || 0, tells: tells[id] || 0,
+                   turnout: turnout[id] || 0, possible_turnout: possible_turnout[id] || 0,
+                   aye_majority: aye_majority[id] || 0)
     end
   end
 
-  def self.all_rebellion_counts
-    Vote.rebellious.group("votes.division_id").count
+  def self.all_rebellion_counts(division_ids = nil)
+    for_divisions(Vote.rebellious, division_ids).group("votes.division_id").count
   end
 
-  def self.all_tells_counts
-    Vote.tells.group("votes.division_id").count
+  def self.all_tells_counts(division_ids = nil)
+    for_divisions(Vote.tells, division_ids).group("votes.division_id").count
   end
 
-  def self.all_turnout_counts
-    Vote.group("votes.division_id").count
+  def self.all_turnout_counts(division_ids = nil)
+    for_divisions(Vote.all, division_ids).group("votes.division_id").count
   end
 
-  def self.all_ayes_counts
-    Vote.ayes.group("votes.division_id").count
+  def self.all_ayes_counts(division_ids = nil)
+    for_divisions(Vote.ayes, division_ids).group("votes.division_id").count
   end
 
-  def self.all_noes_counts
-    Vote.noes.group("votes.division_id").count
+  def self.all_noes_counts(division_ids = nil)
+    for_divisions(Vote.noes, division_ids).group("votes.division_id").count
   end
 
-  def self.all_aye_majority_counts
-    ayes = all_ayes_counts
-    noes = all_noes_counts
+  def self.all_aye_majority_counts(division_ids = nil)
+    ayes = all_ayes_counts(division_ids)
+    noes = all_noes_counts(division_ids)
     keys = (ayes.keys + noes.keys).uniq
     r = {}
     keys.each do |key|
@@ -60,7 +72,16 @@ class DivisionInfo < ApplicationRecord
     r
   end
 
-  def self.all_possible_turnout_counts
-    Division.joins("INNER JOIN members ON divisions.house = members.house AND members.entered_house <= divisions.date AND divisions.date < members.left_house").group("divisions.id").count
+  def self.all_possible_turnout_counts(division_ids = nil)
+    scope = Division.joins("INNER JOIN members ON divisions.house = members.house AND members.entered_house <= divisions.date AND divisions.date < members.left_house")
+    scope = scope.where(divisions: { id: division_ids }) if division_ids
+    scope.group("divisions.id").count
   end
+
+  # Only narrow the scope when we've been given divisions to narrow it to, so
+  # that a full rebuild doesn't pay for a redundant WHERE over every division.
+  def self.for_divisions(scope, division_ids)
+    division_ids ? scope.where(votes: { division_id: division_ids }) : scope
+  end
+  private_class_method :for_divisions
 end

--- a/app/models/whip.rb
+++ b/app/models/whip.rb
@@ -4,8 +4,16 @@ class Whip < ApplicationRecord
   belongs_to :division
 
   def self.update_all!
-    all_possible_votes = Division.joins("LEFT JOIN members ON divisions.house = members.house AND members.entered_house <= divisions.date AND divisions.date < members.left_house").group("divisions.id", :party).count
-    all_votes = calc_all_votes_per_party2
+    update_divisions!(nil)
+  end
+
+  # Rebuild the whip cache for just these divisions. Pass nil to rebuild them all.
+  def self.update_divisions!(division_ids)
+    division_ids = Array(division_ids) if division_ids
+    return if division_ids && division_ids.empty?
+
+    all_possible_votes = possible_votes_per_party(division_ids)
+    all_votes = calc_all_votes_per_party2(division_ids)
 
     all_possible_votes.each_key do |division_id, party|
       votes = all_votes[[division_id, party]]
@@ -55,13 +63,21 @@ class Whip < ApplicationRecord
     end
   end
 
-  def self.calc_all_votes_per_party
-    Division.joins(votes: :member).group("divisions.id", :party, :vote, :teller).count
+  def self.possible_votes_per_party(division_ids = nil)
+    scope = Division.joins("LEFT JOIN members ON divisions.house = members.house AND members.entered_house <= divisions.date AND divisions.date < members.left_house")
+    scope = scope.where(divisions: { id: division_ids }) if division_ids
+    scope.group("divisions.id", :party).count
   end
 
-  def self.calc_all_votes_per_party2
+  def self.calc_all_votes_per_party(division_ids = nil)
+    scope = Division.joins(votes: :member)
+    scope = scope.where(divisions: { id: division_ids }) if division_ids
+    scope.group("divisions.id", :party, :vote, :teller).count
+  end
+
+  def self.calc_all_votes_per_party2(division_ids = nil)
     r = {}
-    calc_all_votes_per_party.each do |k, count|
+    calc_all_votes_per_party(division_ids).each do |k, count|
       division_id, party, vote, teller = k
       votes = r[[division_id, party]] || {}
       votes[[vote, teller]] = count

--- a/app/views/api/v1/divisions/_division.json.jbuilder
+++ b/app/views/api/v1/divisions/_division.json.jbuilder
@@ -8,6 +8,6 @@ json.number division.number
 json.clock_time(division.clock_time&.strip)
 json.aye_votes division.aye_votes
 json.no_votes division.no_votes
-json.possible_turnout division.division_info.possible_turnout
-json.rebellions division.division_info.rebellions
+json.possible_turnout division.division_info&.possible_turnout
+json.rebellions division.division_info&.rebellions
 json.edited division.edited?

--- a/app/views/divisions/_division.html.haml
+++ b/app/views/divisions/_division.html.haml
@@ -20,7 +20,7 @@
 
       %p.division-data.object-data.object-secondary
         %span.division-rebellions.object-data-rebellion
-          = division.rebellions > 0 ? pluralize(division.rebellions, 'rebellion') : "No rebellions"
+          = division.rebellions.to_i > 0 ? pluralize(division.rebellions, 'rebellion') : "No rebellions"
         %span.division-attendance.object-data-attendance
           = fraction_to_percentage_display(division.attendance_fraction)
           attendance

--- a/app/views/divisions/_summary.html.haml
+++ b/app/views/divisions/_summary.html.haml
@@ -9,7 +9,7 @@
       = render "current_policies_list", division: division
 
     %p.division-rebellions-sentence
-      - if division.rebellions > 0
+      - if division.rebellions.to_i > 0
         There
         = division.rebellions == 1 ? "was" : "were"
         %span.rebel= pluralize(division.rebellions, 'rebellion')
@@ -29,6 +29,6 @@
     = render 'summary_table', division: division, whips: whips, votes: votes, members_vote_null: members_vote_null
 
     %figcaption.panel-footer.small
-      - if division.rebellions > 0
+      - if division.rebellions.to_i > 0
         %p <span class="rebel">Red entries</span> are rebel votes against the majority of a party.
       %p Turnout is the percentage of members eligible to vote that did vote.

--- a/app/views/votes/_vote.html.haml
+++ b/app/views/votes/_vote.html.haml
@@ -19,7 +19,7 @@
 
       %p.division-data.object-data.object-secondary
         %span.division-rebellions.object-data-rebellion
-          = vote.division.rebellions > 0 ? pluralize(vote.division.rebellions, 'rebellion') : "No rebellions"
+          = vote.division.rebellions.to_i > 0 ? pluralize(vote.division.rebellions, 'rebellion') : "No rebellions"
         %span.division-attendance.object-data-attendance
           = fraction_to_percentage_display(vote.division.attendance_fraction)
           attendance

--- a/spec/helpers/divisions_helper_spec.rb
+++ b/spec/helpers/divisions_helper_spec.rb
@@ -5,11 +5,31 @@ require "spec_helper"
 describe DivisionsHelper, type: :helper do
   describe "#division_outcome" do
     context "when motion passed" do
-      it { expect(helper.division_outcome(mock_model(Division, passed?: true))).to eq "Passed" }
+      it { expect(helper.division_outcome(mock_model(Division, outcome_known?: true, passed?: true))).to eq "Passed" }
     end
 
     context "when motion not passed" do
-      it { expect(helper.division_outcome(mock_model(Division, passed?: false))).to eq "Not passed" }
+      it { expect(helper.division_outcome(mock_model(Division, outcome_known?: true, passed?: false))).to eq "Not passed" }
+    end
+
+    context "when the division_info cache hasn't been built yet" do
+      it "doesn't claim an outcome it hasn't calculated" do
+        expect(helper.division_outcome(mock_model(Division, outcome_known?: false))).to eq "Unknown"
+      end
+    end
+  end
+
+  describe "#division_outcome_class" do
+    context "when motion passed" do
+      it { expect(helper.division_outcome_class(mock_model(Division, outcome_known?: true, passed?: true))).to eq "division-outcome-passed" }
+    end
+
+    context "when motion not passed" do
+      it { expect(helper.division_outcome_class(mock_model(Division, outcome_known?: true, passed?: false))).to eq "division-outcome-not-passed" }
+    end
+
+    context "when the division_info cache hasn't been built yet" do
+      it { expect(helper.division_outcome_class(mock_model(Division, outcome_known?: false))).to eq "division-outcome-unknown" }
     end
   end
 
@@ -20,29 +40,35 @@ describe DivisionsHelper, type: :helper do
 
     context "with motion with everyone voting one way" do
       it do
-        division = mock_model(Division, majority_fraction: 1.0, unanimous?: true, tied?: false)
+        division = mock_model(Division, outcome_known?: true, majority_fraction: 1.0, unanimous?: true, tied?: false)
         expect(helper.majority_strength_in_words(division)).to eq "unanimously"
       end
     end
 
     context "with motion with a slight majority" do
       it do
-        division = mock_model(Division, majority_fraction: 0.2, unanimous?: false, tied?: false)
+        division = mock_model(Division, outcome_known?: true, majority_fraction: 0.2, unanimous?: false, tied?: false)
         expect(helper.majority_strength_in_words(division)).to eq "by a <span class=\"has-tooltip\" title=\"1 Aye – 0 No\">small majority</span>"
       end
     end
 
     context "with motion with a modest majority" do
       it do
-        division = mock_model(Division, majority_fraction: 0.5, unanimous?: false, tied?: false)
+        division = mock_model(Division, outcome_known?: true, majority_fraction: 0.5, unanimous?: false, tied?: false)
         expect(helper.majority_strength_in_words(division)).to eq "by a <span class=\"has-tooltip\" title=\"1 Aye – 0 No\">modest majority</span>"
       end
     end
 
     context "with motion with a large majority" do
       it do
-        division = mock_model(Division, majority_fraction: 0.9, unanimous?: false, tied?: false)
+        division = mock_model(Division, outcome_known?: true, majority_fraction: 0.9, unanimous?: false, tied?: false)
         expect(helper.majority_strength_in_words(division)).to eq "by a <span class=\"has-tooltip\" title=\"1 Aye – 0 No\">large majority</span>"
+      end
+    end
+
+    context "when the division_info cache hasn't been built yet" do
+      it "says nothing about the majority" do
+        expect(helper.majority_strength_in_words(mock_model(Division, outcome_known?: false))).to eq ""
       end
     end
   end

--- a/spec/lib/data_loader/debates_spec.rb
+++ b/spec/lib/data_loader/debates_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The loader has to leave each division with its caches already built, otherwise
+# the division pages 500 for as long as it takes the separate cache rake task to
+# catch up. See https://github.com/openaustralia/theyvoteforyou/issues/1641
+describe DataLoader::Debates do
+  describe ".load!" do
+    subject(:load_divisions) { described_class.load!(date) }
+
+    let(:date) { Date.new(2009, 11, 25) }
+    let(:xml) { File.read(File.expand_path("../../fixtures/2009-11-25.xml", __dir__)) }
+
+    def url_for(house)
+      "#{Rails.configuration.xml_data_base_url}scrapedxml/#{house}_debates/#{date}.xml"
+    end
+
+    before do
+      stub_request(:get, url_for("representatives")).to_return(body: xml, headers: { "Content-Type" => "text/xml" })
+      stub_request(:get, url_for("senate")).to_return(status: 404)
+
+      # Every member the XML votes reference has to exist or the loader raises.
+      # Split them across two parties so the whip guesses are meaningful.
+      xml.scan(%r{uk\.org\.publicwhip/member/(\d+)}).flatten.uniq.each_with_index do |id, i|
+        Member.create!(gid: "uk.org.publicwhip/member/#{id}",
+                       source_gid: "", title: "", first_name: "Member", last_name: id,
+                       constituency: "", party: i.even? ? "Party A" : "Party B",
+                       house: "representatives",
+                       entered_house: Date.new(2000, 1, 1), left_house: Date.new(2020, 1, 1),
+                       person: create(:person))
+      end
+    end
+
+    it "loads the divisions" do
+      load_divisions
+      expect(Division.count).to eq(2)
+    end
+
+    it "builds a division_info for every division it loads" do
+      load_divisions
+      expect(Division.all).to all(satisfy { |d| d.division_info.present? })
+    end
+
+    it "builds whips for every division it loads" do
+      load_divisions
+      expect(Division.all).to all(satisfy { |d| d.whips.any? })
+    end
+
+    it "leaves every division with a known outcome" do
+      load_divisions
+      expect(Division.all.map(&:outcome_known?)).to all(be(true))
+    end
+
+    it "records a turnout matching the votes it loaded" do
+      load_divisions
+      division = Division.find_by(number: 1)
+      expect(division.division_info.turnout).to eq(division.votes.count)
+    end
+
+    it "calculates the aye majority" do
+      load_divisions
+      division = Division.find_by(number: 1)
+      ayes = division.votes.where(vote: "aye").count
+      noes = division.votes.where(vote: "no").count
+      expect(division.division_info.aye_majority).to eq(ayes - noes)
+    end
+
+    it "rebuilds the caches when the same division is loaded again" do
+      load_divisions
+      expect { described_class.load!(date) }.not_to change(DivisionInfo, :count)
+    end
+  end
+end

--- a/spec/models/division_info_spec.rb
+++ b/spec/models/division_info_spec.rb
@@ -69,6 +69,64 @@ describe DivisionInfo do
     end
   end
 
+  # The loader builds the cache one division at a time inside its transaction, so
+  # these have to be scopable to a single division.
+  # See https://github.com/openaustralia/theyvoteforyou/issues/1641
+  describe ".update_divisions!" do
+    let(:person) { create(:person) }
+    let(:member) do
+      Member.create!(first_name: "Member", last_name: "A", gid: "", source_gid: "",
+                     title: "", constituency: "", party: "A", house: "commons",
+                     entered_house: Date.new(1999, 1, 1), left_house: Date.new(2001, 1, 1),
+                     person: person)
+    end
+    let(:division1) do
+      Division.create!(name: "1", date: Date.new(2000, 1, 1), number: 1, house: "commons",
+                       source_url: "", debate_url: "", motion: "", debate_gid: "")
+    end
+    let(:division2) do
+      Division.create!(name: "2", date: Date.new(2000, 1, 1), number: 2, house: "commons",
+                       source_url: "", debate_url: "", motion: "", debate_gid: "")
+    end
+
+    before do
+      Vote.create!(division: division1, member: member, vote: "aye")
+      Vote.create!(division: division2, member: member, vote: "no")
+    end
+
+    it "builds the cache row for the division it's given" do
+      described_class.update_divisions!(division1.id)
+      expect(division1.reload.division_info).to have_attributes(turnout: 1, aye_majority: 1)
+    end
+
+    it "leaves other divisions alone" do
+      described_class.update_divisions!(division1.id)
+      expect(division2.reload.division_info).to be_nil
+    end
+
+    it "accepts an array of ids" do
+      described_class.update_divisions!([division1.id, division2.id])
+      expect([division1.reload.division_info, division2.reload.division_info]).to all(be_present)
+    end
+
+    it "does nothing when given no divisions" do
+      expect { described_class.update_divisions!([]) }.not_to change(described_class, :count)
+    end
+
+    it "updates an existing cache row rather than duplicating it" do
+      described_class.update_divisions!(division1.id)
+      expect { described_class.update_divisions!(division1.id) }.not_to change(described_class, :count)
+    end
+
+    it "produces the same result as a full rebuild" do
+      described_class.update_divisions!([division1.id, division2.id])
+      scoped = described_class.order(:division_id).pluck(:division_id, :turnout, :aye_majority, :possible_turnout)
+      described_class.delete_all
+      described_class.update_all!
+      expect(described_class.order(:division_id).pluck(:division_id, :turnout, :aye_majority, :possible_turnout)).to eq(scoped)
+    end
+  end
+
   describe "#majority_fraction" do
     it "is 0 for a tied vote" do
       division = described_class.new(turnout: 100, aye_majority: 0)

--- a/spec/models/division_spec.rb
+++ b/spec/models/division_spec.rb
@@ -37,6 +37,64 @@ describe Division do
     end
   end
 
+  # A division is loaded before its division_info cache row is built, so every
+  # one of these has to cope with the association being nil rather than raise.
+  # See https://github.com/openaustralia/theyvoteforyou/issues/1641
+  describe "when the division_info cache hasn't been built yet" do
+    subject(:division) { create(:division) }
+
+    it "has no division_info" do
+      expect(division.division_info).to be_nil
+    end
+
+    it "reports the outcome as not known" do
+      expect(division.outcome_known?).to be(false)
+    end
+
+    describe "the delegated readers return nil rather than raising" do
+      it { expect(division.aye_majority).to be_nil }
+      it { expect(division.turnout).to be_nil }
+      it { expect(division.rebellions).to be_nil }
+      it { expect(division.majority).to be_nil }
+      it { expect(division.majority_fraction).to be_nil }
+    end
+
+    describe "the predicates fall back to false rather than raising" do
+      it { expect(division.passed?).to be(false) }
+      it { expect(division.tied?).to be(false) }
+      it { expect(division.unanimous?).to be(false) }
+    end
+
+    it "returns nil for total_votes" do
+      expect(division.total_votes).to be_nil
+    end
+
+    it "returns nil for possible_votes" do
+      expect(division.possible_votes).to be_nil
+    end
+
+    it "returns nil for attendance_fraction rather than dividing by nil" do
+      expect(division.attendance_fraction).to be_nil
+    end
+  end
+
+  describe "when the division_info cache has been built" do
+    subject(:division) { create(:division) }
+
+    before { create(:division_info, division: division, aye_majority: 5, turnout: 10, possible_turnout: 20, rebellions: 1) }
+
+    it "reports the outcome as known" do
+      expect(division.outcome_known?).to be(true)
+    end
+
+    it { expect(division.passed?).to be(true) }
+    it { expect(division.tied?).to be(false) }
+    it { expect(division.unanimous?).to be(false) }
+    it { expect(division.total_votes).to eq(10) }
+    it { expect(division.possible_votes).to eq(20) }
+    it { expect(division.attendance_fraction).to eq(0.5) }
+  end
+
   describe "::next_month" do
     it "returns the next month" do
       expect(described_class.next_month("2014-12")).to eq("2015-01-01")

--- a/spec/models/whip_spec.rb
+++ b/spec/models/whip_spec.rb
@@ -206,4 +206,62 @@ describe Whip do
       end
     end
   end
+
+  # The loader builds whips one division at a time inside its transaction, and
+  # DivisionInfo's rebellion counts depend on them existing first.
+  # See https://github.com/openaustralia/theyvoteforyou/issues/1641
+  describe ".update_divisions!" do
+    let(:personx) { create(:person) }
+    let(:memberx) do
+      Member.create!(title: "", first_name: "Member", last_name: "X", party: "A",
+                     house: "commons", gid: "", source_gid: "", constituency: "A",
+                     entered_house: Date.new(1999, 1, 1), left_house: Date.new(2001, 1, 1),
+                     person: personx)
+    end
+    let(:divisionx) do
+      Division.create!(date: Date.new(2000, 1, 1), number: 10, house: "commons", name: "X",
+                       source_url: "", debate_url: "", motion: "", debate_gid: "")
+    end
+    let(:divisiony) do
+      Division.create!(date: Date.new(2000, 1, 1), number: 11, house: "commons", name: "Y",
+                       source_url: "", debate_url: "", motion: "", debate_gid: "")
+    end
+
+    before do
+      Vote.create!(division: divisionx, member: memberx, vote: "aye")
+      Vote.create!(division: divisiony, member: memberx, vote: "no")
+    end
+
+    it "builds the whip rows for the division it's given" do
+      described_class.update_divisions!(divisionx.id)
+      expect(divisionx.reload.whips.map(&:party)).to eq(["A"])
+    end
+
+    it "leaves other divisions alone" do
+      described_class.update_divisions!(divisionx.id)
+      expect(divisiony.reload.whips).to be_empty
+    end
+
+    it "guesses the whip from the votes in that division" do
+      described_class.update_divisions!(divisionx.id)
+      expect(divisionx.reload.whips.first).to have_attributes(aye_votes: 1, no_votes: 0, whip_guess: "aye")
+    end
+
+    it "does nothing when given no divisions" do
+      expect { described_class.update_divisions!([]) }.not_to change(described_class, :count)
+    end
+
+    it "is idempotent" do
+      described_class.update_divisions!(divisionx.id)
+      expect { described_class.update_divisions!(divisionx.id) }.not_to change(described_class, :count)
+    end
+
+    it "produces the same result as a full rebuild" do
+      described_class.update_divisions!([divisionx.id, divisiony.id])
+      scoped = described_class.order(:division_id, :party).pluck(:division_id, :party, :aye_votes, :no_votes, :whip_guess)
+      described_class.delete_all
+      described_class.update_all!
+      expect(described_class.order(:division_id, :party).pluck(:division_id, :party, :aye_votes, :no_votes, :whip_guess)).to eq(scoped)
+    end
+  end
 end

--- a/spec/requests/api/v1/divisions_controller_spec.rb
+++ b/spec/requests/api/v1/divisions_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The API reads possible_turnout and rebellions straight off division_info rather
+# than through the delegation on Division, so it needs its own guard against the
+# cache row not existing yet.
+# See https://github.com/openaustralia/theyvoteforyou/issues/1641
+describe Api::V1::DivisionsController, type: :request do
+  let(:user) { create(:confirmed_user) }
+  let(:key) { user.api_key }
+  let(:division) do
+    create(:division, date: Date.new(2014, 1, 1), number: 1, house: "representatives")
+  end
+
+  describe "#index" do
+    context "when the division_info cache hasn't been built yet" do
+      before { division }
+
+      it "responds successfully rather than raising" do
+        get "/api/v1/divisions.json", params: { key: key }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns null for the values it can't calculate yet" do
+        get "/api/v1/divisions.json", params: { key: key }
+        expect(response.parsed_body.first).to include("possible_turnout" => nil, "rebellions" => nil)
+      end
+
+      it "still returns the division's own attributes" do
+        get "/api/v1/divisions.json", params: { key: key }
+        expect(response.parsed_body.first).to include("id" => division.id, "house" => "representatives")
+      end
+    end
+
+    context "when the division_info cache has been built" do
+      before do
+        create(:division_info, division: division, possible_turnout: 150, rebellions: 2)
+      end
+
+      it "returns the cached values" do
+        get "/api/v1/divisions.json", params: { key: key }
+        expect(response.parsed_body.first).to include("possible_turnout" => 150, "rebellions" => 2)
+      end
+    end
+  end
+
+  describe "#show" do
+    context "when the division_info cache hasn't been built yet" do
+      it "responds successfully rather than raising" do
+        get "/api/v1/divisions/#{division.id}.json", params: { key: key }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "without an api key" do
+    it "is unauthorized" do
+      get "/api/v1/divisions.json"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/divisions_controller_uncached_spec.rb
+++ b/spec/requests/divisions_controller_uncached_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression cover for the HTML pages that 500'd when a division had been loaded
+# but its division_info cache row hadn't been built yet.
+# See https://github.com/openaustralia/theyvoteforyou/issues/1641
+describe DivisionsController, type: :request do
+  let!(:division) do
+    create(:division, date: Date.new(2014, 1, 1), number: 1, house: "representatives", name: "An uncached division")
+  end
+
+  it "has no division_info, which is the state under test" do
+    expect(division.division_info).to be_nil
+  end
+
+  describe "the divisions index" do
+    before { get "/divisions/all" }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "lists the division" do
+      expect(response.body).to include("An uncached division")
+    end
+
+    it "says the outcome is unknown rather than claiming one" do
+      expect(response.body).to include("Unknown")
+    end
+
+    it "doesn't claim the division passed or failed" do
+      expect(response.body).not_to include("division-outcome-passed", "division-outcome-not-passed")
+    end
+  end
+
+  describe "when the cache has been built" do
+    before do
+      create(:division_info, division: division, aye_majority: 10, turnout: 100, possible_turnout: 150)
+      get "/divisions/all"
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "reports the real outcome" do
+      expect(response.body).to include("division-outcome-passed")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Divisions were loaded by `application:load:divisions`, but their `division_info` and `whip` cache rows weren't built until the separate `application:cache:all` step. `Division` delegates `turnout`, `aye_majority`, `rebellions`, `majority` and `majority_fraction` to `division_info` with no `allow_nil`, so in between those two steps every page that renders a division returned a 500.

The loader wraps **each division** in its own transaction, so a division became visible to web traffic as soon as that transaction committed. The window therefore opened mid-load, and the daily 9:15am cron hit it just as a manual load did.

Two layers, matching the two fixes suggested on #1641:

**Close the window.** Both caches are now built inside the loader's per-division transaction, so a division and its caches become visible together. Whips are built first, because `DivisionInfo`'s rebellion counts derive from them (`Vote.rebellious` inner joins `whips`, which is why the rake file already declares `task division: :whip`). `DivisionInfo.update_divisions!` and `Whip.update_divisions!` take the ids to rebuild, or `nil` for all of them, which is what `update_all!` now passes. `application:load:daily` and `application:cache:all` are unchanged.

**Degrade instead of crashing.** If a cache row is missing for any other reason, the delegation now allows nil - matching the existing `member_info` delegation on `Member` - and the outcome renders as "Unknown" rather than asserting a result we haven't calculated. Showing "Not passed" for a division that may well have passed would misreport a parliamentary vote, so the helpers check `outcome_known?` before displaying an outcome. `allow_nil` alone wouldn't have been enough for the API: `api/v1/divisions/_division.json.jbuilder` reads `division_info` directly rather than through the delegation, so it gets its own guard and emits `null`.

Also switches `DivisionInfo`'s save to `update!` - a silently failed save was one of the ways a division could end up with no cache row.

Not addressed here: `MemberInfo` has the identical load/cache gap, but `Member`'s delegation is already guarded so it degrades quietly rather than 500ing. Worth a separate issue.

## Motivation and Context

Resolves #1641.

Sentry recorded a burst of this on 2026-08-18, 23:16:34-23:22:53 UTC - about 90 seconds after 09:15 AEST, matching the `15 9 * * 1-5` cron. ~36 events across five issues:

| Sentry | Controller | Events |
| --- | --- | --- |
| THEY-VOTE-FOR-YOU-A | `Api::V1::DivisionsController#index` | 23 |
| THEY-VOTE-FOR-YOU-E | `MembersController#show` | 7 |
| THEY-VOTE-FOR-YOU-C | `DivisionsController#index` | 4 |
| THEY-VOTE-FOR-YOU-D | `HomeController#search` | 1 |
| THEY-VOTE-FOR-YOU-B | `PeopleDistancesController#show` | 1 |

This is long-standing: #1269 described the same daily-cron window back in 2021 and was closed as stale; #1204 and #1270 are earlier duplicates.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

448 examples, 0 failures. `rubocop --parallel` clean.

Every layer is covered by a test that was confirmed to **fail without its fix**:

- `spec/lib/data_loader/debates_spec.rb` (new) - drives the real loader against the existing `2009-11-25.xml` fixture with the HTTP fetch stubbed, and asserts each loaded division comes out with its caches built. 5 of its 7 examples fail without the loader change.
- `spec/requests/divisions_controller_uncached_spec.rb` (new) - renders `/divisions/all` with an uncached division, asserts 200 and that the page says "Unknown" rather than claiming an outcome. Fails with `NoMethodError` without `allow_nil`.
- `spec/requests/api/v1/divisions_controller_spec.rb` (new) - the regression test for THEY-VOTE-FOR-YOU-A. The API namespace had no coverage at all before this.
- `spec/models/division_spec.rb` - `tied?` and `unanimous?` had no direct coverage previously.
- `spec/models/division_info_spec.rb`, `spec/models/whip_spec.rb` - the scoped rebuilds, including that each produces the same result as a full rebuild.

Two things I checked specifically:

1. **No fixture churn.** `spec/html_compare_helper.rb` hardcodes `overwrite = true`, so a rendering change silently rewrites the static-page fixtures. `spec/fixtures/` is untouched after a full run, as expected - the fixture divisions all have a `division_info`, so the Unknown branch never fires.
2. **No performance regression on the nightly rebuild.** Having `update_all!` pass every division id would have produced an `IN (...)` list with tens of thousands of entries. It passes `nil` instead, so the full rebuild emits exactly the same unscoped aggregates as before - verified by capturing the SQL. Divisions with no votes at all still get their row of zeroes.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code:claude-opus-5
