### PR TITLE
Load Sentry browser SDK from the EU CDN host

### DIFF
--- a/app/views/application/_sentry_javascript.html.haml
+++ b/app/views/application/_sentry_javascript.html.haml
@@ -17,4 +17,7 @@
         replaysOnErrorSampleRate: 1.0
       });
     };
-  = javascript_include_tag "https://js.sentry-cdn.com/#{public_key}.min.js", crossorigin: "anonymous"
+  -# The Loader Script host is region-specific and our org is in Sentry's EU region.
+  -# The US host (js.sentry-cdn.com) answers 200 with a no-op stub, which would
+  -# leave every frontend signal silently inert. See #1699.
+  = javascript_include_tag "https://js-de.sentry-cdn.com/#{public_key}.min.js", crossorigin: "anonymous"


### PR DESCRIPTION
## Description

Changes the browser Sentry Loader Script host in `_sentry_javascript.html.haml` from `js.sentry-cdn.com` (US) to `js-de.sentry-cdn.com` (EU), and adds a comment explaining why the host is region-specific.

## Motivation and Context

Our Sentry organisation `oaf-org-au` is in the EU region, so the Loader Script has to be served from the EU host. Fetching our project's public key from the US host returns HTTP 200, but the body is a 567-byte no-op stub instead of the SDK:

```js
function _sentry_noopWarning() {
  console.warn("The Sentry loader you are trying to use isn't working anymore, check your configuration.");
}
var Sentry = { addBreadcrumb: _sentry_noopWarning, ... };
```

Because that stub's `Sentry.init` does nothing, `window.sentryOnLoad` runs but has no effect, and every frontend signal is silently inert:

- browser error reporting
- browser tracing (`tracesSampleRate: 0.1`)
- on-error session replay (`replaysOnErrorSampleRate: 1.0`), added in #1688

There is no console error and no failed request, so nothing surfaces it - the page looks fine and Sentry just stays empty.

The same key on `js-de.sentry-cdn.com` returns the real 2,884-byte loader, wired to `ingest.de.sentry.io`.

This is latent rather than live: per #1690 production still runs `e4db521` (deployed 2026-08-14), which predates the frontend Sentry work, so this lands before the bug can reach anyone.

The backend was never affected - `config/initializers/sentry.rb` uses the DSN from credentials, which already points at `ingest.de.sentry.io`, and `.sentryclirc` already has `url=https://de.sentry.io`.

Resolves #1699

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

Verified at the CDN rather than in a browser, by requesting the project's public key from both hosts:

```
$ curl -sS -o /dev/null -w "%{http_code} %{size_download}\n" https://js.sentry-cdn.com/<key>.min.js
200 567      # no-op stub
$ curl -sS -o /dev/null -w "%{http_code} %{size_download}\n" https://js-de.sentry-cdn.com/<key>.min.js
200 2884     # real loader, references ingest.de.sentry.io
```

- [ ] Ran automated tests on my own system

I could not run the suite locally - this checkout has no `config/database.yml` and there is no `docker-compose.yml` in the repo, so there is no database to run against. `bin/rubocop --parallel` passes (170 files, no offenses). No spec covers this partial, so the suite would not have caught this either way.

- [x] Confirmed it passed the GitHub actions tests

All checks green: test 1m43s, lint 19s, Socket Security both pass. Taken out of draft on that basis, per CONTRIBUTING.

**Still needs confirming after deploy:** this fixes the host, which is verified. It does not prove the end-to-end path. Once `main` is deployed, a browser error actually landing in the `they-vote-for-you` project is what confirms it.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: Claude Code:claude-opus-5
