### PR TITLE
Extend Sentry: CLI v4 support, PII, trace stitching, cron instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,20 @@ Each deploy notifies [Sentry](https://oaf-org-au.sentry.io/) of the new
 release so that errors can be linked back to the commits that introduced them.
 This runs on your machine as part of the deploy and needs a one-off setup:
 
-1. Install [sentry-cli](https://docs.sentry.io/product/cli/):
-   `brew install getsentry/tools/sentry-cli` on a Mac, or on Linux
-   `curl -sL https://sentry.io/get-cli/ | sh`.
-2. Create a personal auth token at https://oaf-org-au.sentry.io under
-   Settings → Auth Tokens → Create New Token, with only the
-   `project:releases` scope.
-3. Put the token in `~/.sentryclirc`:
+1. Install the [Sentry CLI](https://cli.sentry.dev/getting-started/) (v4,
+   the `sentry` binary): `brew install getsentry/tools/sentry` on a Mac, or
+   on Linux `curl https://cli.sentry.dev/install -fsS | bash`. The older v3
+   `sentry-cli` binary is also still supported if you have it installed.
+2. Authenticate. The easiest way is the browser-based login (v4 only):
+
+   ```
+   sentry auth login
+   ```
+
+   Alternatively (and for v3), create a personal auth token at
+   https://oaf-org-au.sentry.io under Settings → Auth Tokens → Create New
+   Token, with only the `project:releases` scope, and put it in
+   `~/.sentryclirc`:
 
    ```
    [auth]
@@ -194,7 +201,7 @@ This runs on your machine as part of the deploy and needs a one-off setup:
 
    or set the `SENTRY_AUTH_TOKEN` environment variable. The org, project and
    URL are picked up automatically from this repository's `.sentryclirc`.
-4. Check it works with `sentry-cli info`.
+3. Check it works with `sentry auth status` (v4) or `sentry-cli info` (v3).
 
 If you haven't done this setup, deploys still work as normal; the release
 tracking step is skipped with a warning.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   after_action :store_location
   before_action :set_paper_trail_whodunnit
+  before_action :set_sentry_user
 
   include Pundit::Authorization
 
@@ -21,6 +22,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  # Attach the signed-in user to Sentry events so errors show who was affected.
+  # Sentry's Rack middleware resets the scope every request, so this can't leak
+  # between requests.
+  def set_sentry_user
+    Sentry.set_user(id: current_user.id, email: current_user.email, username: current_user.name) if user_signed_in?
+  end
 
   def store_location
     # store last url as long as it isn't a /users path

--- a/app/lib/card_screenshotter/utils.rb
+++ b/app/lib/card_screenshotter/utils.rb
@@ -43,6 +43,7 @@ module CardScreenshotter
       end
       screenshot_and_save_without_restart(url, path)
       @count += 1
+      Sentry::Metrics.count("cards.screenshots.generated")
     end
 
     def screenshot_and_save_without_restart(url, path)

--- a/app/lib/data_loader/debates.rb
+++ b/app/lib/data_loader/debates.rb
@@ -13,10 +13,14 @@ module DataLoader
         House.australian.each do |house|
           url = "#{Rails.configuration.xml_data_base_url}scrapedxml/#{house}_debates/#{date}.xml"
           begin
-            xml_document = Nokogiri::XML(agent.get(url).body)
+            xml_document = Sentry.with_child_span(op: "http.client", description: "Fetch #{house} debates XML for #{date}") do |span|
+              span&.set_data("http.url", url)
+              Nokogiri::XML(agent.get(url).body)
+            end
           rescue Mechanize::ResponseCodeError => e
             raise e if e.response_code != "404"
 
+            Sentry::Metrics.count("data_load.divisions.xml_missing", attributes: { house: house })
             Rails.logger.info "No XML file found for #{house} on #{date} at #{url}"
             next
           end
@@ -26,40 +30,47 @@ module DataLoader
           debates = DebatesXml.new(xml_document, house)
           Rails.logger.info "No debates found in XML for #{house} on #{date}" if debates.divisions.empty?
 
-          Rails.logger.warn "Division reload mismatch! #{house} #{date}: #{existing_divisions.count} divisions in the database and #{debates.divisions.count} in the XML" if existing_divisions && existing_divisions.count != debates.divisions.count
+          if existing_divisions && existing_divisions.count != debates.divisions.count
+            Rails.logger.warn "Division reload mismatch! #{house} #{date}: #{existing_divisions.count} divisions in the database and #{debates.divisions.count} in the XML"
+            Sentry::Metrics.count("data_load.divisions.mismatch", attributes: { house: house })
+          end
 
           debates.divisions.each do |d|
             Rails.logger.info "Saving division: #{d.house} #{d.date} #{d.number}"
-            ActiveRecord::Base.transaction do
-              bills = d.bills.map do |bill_hash|
-                bill = Bill.find_or_initialize_by(official_id: bill_hash[:id])
-                bill.update!(url: bill_hash[:url], title: bill_hash[:title])
-                bill
+            Sentry.with_child_span(op: "task", description: "Save division #{d.house} #{d.date} #{d.number}") do |span|
+              span&.set_data(:votes_count, d.votes.count)
+              ActiveRecord::Base.transaction do
+                bills = d.bills.map do |bill_hash|
+                  bill = Bill.find_or_initialize_by(official_id: bill_hash[:id])
+                  bill.update!(url: bill_hash[:url], title: bill_hash[:title])
+                  bill
+                end
+
+                division = Division.find_or_initialize_by(date: d.date, number: d.number, house: d.house)
+                division.update!(name: d.name,
+                                 source_url: d.source_url,
+                                 debate_url: d.debate_url,
+                                 debate_gid: d.debate_gid,
+                                 motion: d.motion,
+                                 clock_time: d.clock_time,
+                                 bills: bills)
+
+                division.votes.delete_all(:delete_all)
+                d.votes.each do |gid, vote|
+                  member = Member.find_by(gid: gid)
+                  raise "Couldn't find member by gid #{gid}" if member.nil?
+
+                  Vote.create!(division: division, member: member, vote: vote[0], teller: vote[1])
+                end
+
+                # Build the caches the division pages read from before we commit, so
+                # the division is never visible without them. Whips first - the
+                # rebellion counts in DivisionInfo are derived from them.
+                Whip.update_divisions!(division.id)
+                DivisionInfo.update_divisions!(division.id)
               end
-
-              division = Division.find_or_initialize_by(date: d.date, number: d.number, house: d.house)
-              division.update!(name: d.name,
-                               source_url: d.source_url,
-                               debate_url: d.debate_url,
-                               debate_gid: d.debate_gid,
-                               motion: d.motion,
-                               clock_time: d.clock_time,
-                               bills: bills)
-
-              division.votes.delete_all(:delete_all)
-              d.votes.each do |gid, vote|
-                member = Member.find_by(gid: gid)
-                raise "Couldn't find member by gid #{gid}" if member.nil?
-
-                Vote.create!(division: division, member: member, vote: vote[0], teller: vote[1])
-              end
-
-              # Build the caches the division pages read from before we commit, so
-              # the division is never visible without them. Whips first - the
-              # rebellion counts in DivisionInfo are derived from them.
-              Whip.update_divisions!(division.id)
-              DivisionInfo.update_divisions!(division.id)
             end
+            Sentry::Metrics.count("data_load.divisions.loaded", attributes: { house: house })
           end
         end
       end

--- a/app/lib/data_loader/members.rb
+++ b/app/lib/data_loader/members.rb
@@ -47,7 +47,9 @@ module DataLoader
                       source_gid: "")
           end
         end
-        Rails.logger.info "Loaded #{Member.count} members"
+        total = Member.count
+        Rails.logger.info "Loaded #{total} members"
+        Sentry::Metrics.gauge("data_load.members.total", total)
       end
     end
   end

--- a/app/views/application/_sentry_javascript.html.haml
+++ b/app/views/application/_sentry_javascript.html.haml
@@ -3,12 +3,21 @@
   - public_key = URI.parse(dsn).user
   -# Pick up the release detected by the backend Sentry SDK so frontend and backend events match
   - release = defined?(Sentry) && Sentry.respond_to?(:configuration) && Sentry.configuration&.release
+  -# Meta tags the browser SDK reads on pageload to continue the backend trace,
+  -# stitching the browser transaction to the Rails transaction that rendered it
+  - if defined?(Sentry) && Sentry.initialized?
+    = Sentry.get_trace_propagation_meta.html_safe
+  -# Tie frontend events to the same user as backend ones (self-contained on the
+  -# user's own page; j escapes quotes and </ so the value can't break out)
+  - sentry_user_js = user_signed_in? ? "Sentry.setUser({ id: '#{j current_user.id.to_s}', email: '#{j current_user.email}' });" : ""
   -# window.sentryOnLoad must be defined before the Loader Script tag so the
   -# lazy-loaded SDK picks up our configuration when it initialises
   :javascript
     window.sentryOnLoad = function () {
       Sentry.init({
         environment: '#{j Rails.env}'#{", release: '#{j release}'" if release},
+        // Send user IP with events, matching the backend's send_default_pii
+        sendDefaultPii: true,
         // Sample 10% of pageloads/navigations for browser tracing
         tracesSampleRate: 0.1,
         // Only record session replays when an error occurs, with default
@@ -16,6 +25,7 @@
         replaysSessionSampleRate: 0,
         replaysOnErrorSampleRate: 1.0
       });
+      #{sentry_user_js}
     };
   -# The Loader Script host is region-specific and our org is in Sentry's EU region.
   -# The US host (js.sentry-cdn.com) answers 200 with a no-op stub, which would

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,12 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [:password]
+#
+# This filter also applies to the request data Sentry captures with events
+# (send_default_pii is enabled in sentry.rb). :key is the API key query
+# parameter; the Devise tokens appear in query strings of emailed links.
+Rails.application.config.filter_parameters += %i[password key reset_password_token confirmation_token]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,7 +8,10 @@ Sentry.init do |config|
   config.traces_sample_rate = 0.1
   # If the infrastructure repo's otel-sidecar collector lands, traces can route through it
   # via sentry-opentelemetry + config.otlp.* instead of traces_sample_rate
-  config.send_default_pii = false
+  # Include user IPs and request data (cookies, headers, query strings) with
+  # events. Secrets that travel in query strings (API keys, Devise tokens) are
+  # scrubbed via Rails' filter_parameters - see filter_parameter_logging.rb
+  config.send_default_pii = true
   # Send Rails logs to Sentry as structured logs
   config.enable_logs = true
   config.enabled_patches << :logger

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -4,21 +4,80 @@ namespace :sentry do
   desc "Notify Sentry of a new release and deploy"
   task :notify_deploy do
     run_locally do
-      unless test("which sentry-cli")
-        warn "Sentry: sentry-cli not installed, skipping release tracking (see README)"
+      # Support both v4 ("sentry") and v3 ("sentry-cli") of the Sentry CLI.
+      # See https://cli.sentry.dev/migrating-from-v3/
+      cli =
+        if test("which sentry")
+          :sentry
+        elsif test("which sentry-cli")
+          :"sentry-cli"
+        end
+
+      unless cli
+        warn "Sentry: sentry (or sentry-cli) not installed, skipping release tracking (see README)"
         next
       end
 
       revision = fetch(:current_revision)
       environment = fetch(:rails_env, fetch(:stage))
+      # "openaustralia/theyvoteforyou" - the repository name as known to
+      # Sentry's GitHub integration
+      repo = fetch(:repo_url)[%r{github\.com[:/](.+?)(?:\.git)?\z}, 1]
 
-      begin
-        execute :"sentry-cli", :releases, :new, revision
-        execute :"sentry-cli", :releases, :"set-commits", revision, "--local"
-        execute :"sentry-cli", :releases, :finalize, revision
-        execute :"sentry-cli", :deploys, :new, "--release", revision, "-e", environment
+      # v4 doesn't pick up the project from the repository's .sentryclirc the
+      # way v3 does, so pass org and project explicitly (both versions accept
+      # these flags).
+      sentryclirc = File.read(File.expand_path("../../../.sentryclirc", __dir__))
+      org = sentryclirc[/^org\s*=\s*(\S+)/, 1]
+      project = sentryclirc[/^project\s*=\s*(\S+)/, 1]
+
+      # v4 renamed the "releases" command group to "release".
+      release_group = cli == :sentry ? :release : :releases
+      release_cmd = lambda do |*args|
+        execute cli, release_group, *args, "--org", org, "--project", project
+      end
+
+      created = begin
+        release_cmd.call(:new, revision)
+        true
       rescue StandardError => e
-        warn "Sentry: release tracking failed, continuing deploy: #{e.message}"
+        warn "Sentry: creating release failed, continuing deploy: #{e.message}"
+        false
+      end
+
+      if created
+        begin
+          # Associate the exact deployed commit server-side via Sentry's
+          # GitHub integration - Sentry works out the commit range from the
+          # previous release. (--auto would use the local checkout's HEAD,
+          # which isn't necessarily the deployed revision.)
+          release_cmd.call(:"set-commits", revision, "--commit", "#{repo}@#{revision}")
+        rescue StandardError => e
+          warn "Sentry: set-commits via GitHub integration failed, trying local git history: #{e.message}"
+          begin
+            release_cmd.call(:"set-commits", revision, "--local")
+          rescue StandardError => e
+            warn "Sentry: associating commits failed, continuing deploy: #{e.message}"
+          end
+        end
+
+        begin
+          release_cmd.call(:finalize, revision)
+        rescue StandardError => e
+          warn "Sentry: finalizing release failed, continuing deploy: #{e.message}"
+        end
+
+        begin
+          if cli == :sentry
+            # v4: "deploys new" is gone; environment is a positional argument.
+            release_cmd.call(:deploy, revision, environment)
+          else
+            execute cli, :deploys, :new, "--release", revision, "-e", environment,
+                    "--org", org, "--project", project
+          end
+        rescue StandardError => e
+          warn "Sentry: recording deploy failed, continuing deploy: #{e.message}"
+        end
       end
     end
   end

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -14,16 +14,34 @@ def with_sentry_cron_monitoring(slug, crontab, &block)
     timezone: "Australia/Sydney"
   )
   check_in_id = Sentry.capture_check_in(slug, :in_progress, monitor_config: monitor_config)
+  # Rake tasks run outside any automatic Sentry transaction, so start one here
+  # to make the sentry_stage spans visible in a trace. sampled: true because
+  # these run once a day - the web traces_sample_rate would drop most runs.
+  transaction = Sentry.start_transaction(name: slug, op: "cron", sampled: true)
+  Sentry.get_current_scope.set_span(transaction) if transaction
   start = Sentry.utc_now
   begin
     block.call
+    transaction&.set_status("ok")
     Sentry.capture_check_in(slug, :ok, check_in_id: check_in_id, duration: Sentry.utc_now - start,
                                        monitor_config: monitor_config)
   rescue StandardError
+    transaction&.set_status("internal_error")
     Sentry.capture_check_in(slug, :error, check_in_id: check_in_id, duration: Sentry.utc_now - start,
                                           monitor_config: monitor_config)
     raise
+  ensure
+    transaction&.finish
   end
+end
+
+# Wrap a stage of a cron run in a child span so the trace shows where the time
+# goes. Safely a no-op when there's no active transaction (e.g. running a task
+# by hand) or Sentry isn't initialized.
+def sentry_stage(name, &block)
+  return block.call unless defined?(Sentry)
+
+  Sentry.with_child_span(op: "task", description: name) { |_span| block.call }
 end
 
 namespace :application do
@@ -36,39 +54,49 @@ namespace :application do
 
     desc "Rebuilds the whole cache of agreement between people"
     task people_distances: :environment do
-      people = Person.all
-      progressbar = ProgressBar.create(title: "Updating people distance cache", total: people.count, format: "%t: |%B| %E %a")
-      people.find_each do |person|
-        PeopleDistance.update_person(person)
-        progressbar.increment
+      sentry_stage("application:cache:people_distances") do
+        people = Person.all
+        progressbar = ProgressBar.create(title: "Updating people distance cache", total: people.count, format: "%t: |%B| %E %a")
+        people.find_each do |person|
+          PeopleDistance.update_person(person)
+          progressbar.increment
+        end
       end
     end
 
     desc "Update cache of guessed whips"
     task whip: :environment do
-      puts "Updating cache of guessed whips..."
-      Whip.update_all!
+      sentry_stage("application:cache:whip") do
+        puts "Updating cache of guessed whips..."
+        Whip.update_all!
+      end
     end
 
     desc "Update cache of member attendance, rebellions, etc"
     task member: :whip do
-      puts "Updating member cache..."
-      MemberInfo.update_all!
+      sentry_stage("application:cache:member") do
+        puts "Updating member cache..."
+        MemberInfo.update_all!
+      end
     end
 
     desc "Update cache of division attendance, rebellions, etc"
     task division: :whip do
-      puts "Updating division cache..."
-      DivisionInfo.update_all!
+      sentry_stage("application:cache:division") do
+        puts "Updating division cache..."
+        DivisionInfo.update_all!
+      end
     end
 
     desc "Update cache of policy distances"
     task policy_distances: :environment do
-      policies = Policy.all
-      progressbar = ProgressBar.create(title: "Updating policy distance cache", total: policies.count, format: "%t: |%B| %E %a")
-      policies.find_each do |policy|
-        policy.calculate_person_distances!
-        progressbar.increment
+      sentry_stage("application:cache:policy_distances") do
+        policies = Policy.all
+        progressbar = ProgressBar.create(title: "Updating policy distance cache", total: policies.count, format: "%t: |%B| %E %a")
+        policies.find_each do |policy|
+          policy.calculate_person_distances!
+          progressbar.increment
+        end
       end
     end
 
@@ -76,20 +104,22 @@ namespace :application do
     # an incorrect member can be attached to a vote, the effect it has and how this fixes it.
     desc "Fix member attached to votes"
     task member_vote_fix: :environment do
-      Vote.includes(:division, :member).find_each do |vote|
-        if vote.division.nil?
-          puts "WARNING: Vote #{vote.id} points to non-existent division"
-          next
-        end
-        unless vote.member.could_have_voted_in_division?(vote.division)
-          puts "Vote #{vote.id} has an incorrect member. Fixing"
-          # Find the member who could have voted on this division
-          vote.member = vote.member.person.member_in_division(vote.division)
-          if vote.member.nil?
-            puts "WARNING: Couldn't find a member to fix vote #{vote.id} with division #{vote.division_id}. vote = #{vote.inspect}"
+      sentry_stage("application:cache:member_vote_fix") do
+        Vote.includes(:division, :member).find_each do |vote|
+          if vote.division.nil?
+            puts "WARNING: Vote #{vote.id} points to non-existent division"
             next
           end
-          vote.save!
+          unless vote.member.could_have_voted_in_division?(vote.division)
+            puts "Vote #{vote.id} has an incorrect member. Fixing"
+            # Find the member who could have voted on this division
+            vote.member = vote.member.person.member_in_division(vote.division)
+            if vote.member.nil?
+              puts "WARNING: Couldn't find a member to fix vote #{vote.id} with division #{vote.division_id}. vote = #{vote.inspect}"
+              next
+            end
+            vote.save!
+          end
         end
       end
     end
@@ -107,21 +137,23 @@ namespace :application do
   namespace :load do
     desc "Reloads members, offices and electorates from XML files and updates people images"
     task members: %i[environment set_logger_to_stdout] do
-      DataLoader::Electorates.load!
-      DataLoader::Members.load!
+      sentry_stage("DataLoader::Electorates.load!") { DataLoader::Electorates.load! }
+      sentry_stage("DataLoader::Members.load!") { DataLoader::Members.load! }
       # This fixes up members attached to votes
       task("application:cache:member_vote_fix").invoke
       # Offices need to be loaded after new people/members
-      DataLoader::Offices.load!
-      DataLoader::People.load_missing_images!
+      sentry_stage("DataLoader::Offices.load!") { DataLoader::Offices.load! }
+      sentry_stage("DataLoader::People.load_missing_images!") { DataLoader::People.load_missing_images! }
     end
 
     desc "Load divisions from XML for a specified date"
     task :divisions, %i[from_date to_date] => %i[environment set_logger_to_stdout] do |_t, args|
-      if args[:to_date]
-        DataLoader::Debates.load!(Date.parse(args[:from_date]), Date.parse(args[:to_date]))
-      else
-        DataLoader::Debates.load!(Date.parse(args[:from_date]))
+      sentry_stage("application:load:divisions") do
+        if args[:to_date]
+          DataLoader::Debates.load!(Date.parse(args[:from_date]), Date.parse(args[:to_date]))
+        else
+          DataLoader::Debates.load!(Date.parse(args[:from_date]))
+        end
       end
     end
 
@@ -241,27 +273,27 @@ namespace :application do
 
     desc "Generate social media cards for how people vote on particular policies"
     task person_policies: :environment do
-      CardScreenshotter::PersonPolicies.run
+      sentry_stage("application:cards:person_policies") { CardScreenshotter::PersonPolicies.run }
     end
 
     desc "Generate social media cards for people"
     task people: :environment do
-      CardScreenshotter::Members.run
+      sentry_stage("application:cards:people") { CardScreenshotter::Members.run }
     end
 
     desc "Generate social media cards for each category a member votes"
     task person_policies_category: :environment do
-      CardScreenshotter::MemberPolicyCategory.run
+      sentry_stage("application:cards:person_policies_category") { CardScreenshotter::MemberPolicyCategory.run }
     end
 
     desc "Generate social media cards for policies"
     task policies: :environment do
-      CardScreenshotter::Policies.run
+      sentry_stage("application:cards:policies") { CardScreenshotter::Policies.run }
     end
 
     desc "Generate social media cards for each category on a policy"
     task policies_category: :environment do
-      CardScreenshotter::PoliciesCategory.run
+      sentry_stage("application:cards:policies_category") { CardScreenshotter::PoliciesCategory.run }
     end
   end
 end


### PR DESCRIPTION
## Description

Three related extensions to our Sentry setup:

1. **Sentry CLI v4 support in deploy release tracking** (`lib/capistrano/tasks/sentry.rake`). CLI v4 renamed the binary (`sentry-cli` → `sentry`), the `releases` command group (→ `release`), and replaced `deploys new` with `release deploy` ([migration guide](https://cli.sentry.dev/migrating-from-v3/)). The Capistrano task now detects whichever binary is installed, preferring v4, so deployers can migrate at their own pace. It also fixes the silent failure that left release `e4db521` orphaned in Sentry with no commits or deploy: the four CLI steps shared one `rescue`, so a `set-commits` failure skipped `finalize` and the deploy record. Each step now warns and continues independently, commits are associated server-side via the GitHub integration (`--commit repo@sha`) with `--local` as fallback, and org/project are passed explicitly (v4 doesn't read the project from the repo `.sentryclirc` on `release new`). README setup instructions updated for both versions.

2. **PII + user context + trace stitching**. `send_default_pii` enabled on both backend and browser so events carry IPs and request data; signed-in users attached to events (id/email/name) on both sides. `filter_parameters` extended to scrub the API `?key=` query parameter and Devise reset/confirmation tokens from captured request data (and from Rails logs, where they were previously exposed). Sentry trace-propagation meta tags rendered in the layout so browser pageload transactions continue the Rails trace.

3. **Spans + metrics on the cron pipelines**. `with_sentry_cron_monitoring` now starts a transaction per cron run (`sampled: true` — one run a day would mostly be dropped at our 0.1 sample rate), and a `sentry_stage` helper wraps each stage of the daily load and nightly cards runs, so traces show where the hours go. `DataLoader::Debates` gets per-fetch and per-division spans plus counters (`data_load.divisions.loaded`/`.mismatch`/`.xml_missing` by house — the reload mismatch was previously only a log warning), a `data_load.members.total` gauge, and a `cards.screenshots.generated` counter.

## Motivation and Context

Follows on from #1683/#1689 (Sentry adoption, Honeybadger removal) and #1700. The release-tracking half was diagnosed live: the current production release `e4db521` sat in Sentry unfinalized with zero commits and no deploy record because of the swallowed `set-commits` failure. That release has been backfilled by hand (commits, finalize, production deploy with real timestamps); this PR stops it happening again and makes the tracking work with the new CLI.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system

  - The Capistrano task's exact v4 command sequence was run end to end against the real Sentry org using a probe release (create → set-commits via GitHub integration → finalize → deploy) and then deleted. Both CLI detection branches exercised.
  - Span/metric behaviour smoke-tested in-process against the bundled sentry-ruby 6.7.0: uninitialized → safe no-op (dev has no DSN); initialized → cron transaction → nested stage/child spans + trace-linked metric all created.
  - RuboCop clean on all touched files; Haml partial compiles; full Rakefile loads (`rake -T` resolves the tasks).

- [ ] Ran automated tests on my own system

  Local checkout has no `config/database.yml`, so the suite runs in CI only.

- [ ] Confirmed it passed the GitHub actions tests

**Still needs confirming after deploy:** next `application:load:daily` run should produce a trace named `application-load-daily` with the stage breakdown and `data_load.*` metrics; a signed-in error event should carry user context; page source should show the `sentry-trace`/`baggage` meta tags; the next deploy should attach commits + deploy record to its release.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.