### PR TITLE
Pin Sentry gems to version 6.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,14 @@ gem "devise"
 gem "attribute-defaults"
 gem "diffy"
 gem "ranker"
-gem "sentry-ruby"
-gem "sentry-rails"
-gem "sentry-delayed_job"
+# Pinned to the 6.x line: 7.0.0 removed `enable_logs`, which
+# config/initializers/sentry.rb sets, changed the PII and metrics defaults,
+# and flipped the config.otlp.* exporter defaults to false. Deploys install
+# from Gemfile.lock in deployment mode so they can't drift, but without a
+# constraint the next `bundle update` takes the new major.
+gem "sentry-ruby", "~> 6.7"
+gem "sentry-rails", "~> 6.7"
+gem "sentry-delayed_job", "~> 6.7"
 # Sampling profiler used by Sentry profiling
 gem "vernier"
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -782,9 +782,9 @@ DEPENDENCIES
   searchkick
   seed_dump
   selenium-webdriver
-  sentry-delayed_job
-  sentry-rails
-  sentry-ruby
+  sentry-delayed_job (~> 6.7)
+  sentry-rails (~> 6.7)
+  sentry-ruby (~> 6.7)
   simple_form
   simplecov
   skylight


### PR DESCRIPTION
## What and why

Pin Sentry gems to version 6.7 to prevent major updates that could introduce breaking changes. This change ensures stability in the application by avoiding unexpected behavior from newer versions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [x] Ran `/code-review` (or equivalent): Not required for a simple Gemfile pin.

- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

