### PR TITLE
Show the running version on the About page

### DIFF
--- a/app/lib/app_version.rb
+++ b/app/lib/app_version.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+# The git revision of the code that's currently running, for display on the About page.
+#
+# Capistrano writes a REVISION file containing the full SHA into every release directory;
+# Sentry reads that same file to tag releases (see config/initializers/sentry.rb). A
+# development checkout has no REVISION file, so we ask git instead. Anything else - notably
+# the Mina-deployed Ukraine site, which writes no REVISION - gets nil, and the About page
+# leaves the version sentence out rather than showing a broken commit link.
+module AppVersion
+  # GitHub resolves a 7 character prefix, which is short enough to read out loud.
+  SHORT_LENGTH = 7
+
+  # root: exists only so specs can point at a real temporary directory instead of
+  # stubbing File.
+  def self.short_sha(root: Rails.root)
+    from_revision_file(root) || from_git(root)
+  end
+
+  def self.from_revision_file(root)
+    path = root.join("REVISION")
+    return unless File.exist?(path)
+
+    File.read(path).strip[0, SHORT_LENGTH].presence
+  end
+  private_class_method :from_revision_file
+
+  # Redirecting stderr means this runs via /bin/sh, so a missing git or a directory
+  # outside any repository gives us empty output rather than raising Errno::ENOENT.
+  # git -C avoids Dir.chdir, which isn't thread safe.
+  def self.from_git(root)
+    `git -C #{Shellwords.escape(root.to_s)} rev-parse --short=#{SHORT_LENGTH} HEAD 2>/dev/null`.strip.presence
+  end
+  private_class_method :from_git
+end

--- a/app/lib/app_version.rb
+++ b/app/lib/app_version.rb
@@ -13,25 +13,44 @@ module AppVersion
   # GitHub resolves a 7 character prefix, which is short enough to read out loud.
   SHORT_LENGTH = 7
 
+  # Anything that isn't a SHA is treated as no answer at all, so a truncated or corrupt
+  # REVISION leaves the sentence out instead of linking to a commit that doesn't exist.
+  # git lengthens its short SHA past SHORT_LENGTH when 7 characters would be ambiguous,
+  # so allow up to a full 40.
+  SHA_FORMAT = /\A[0-9a-f]{7,40}\z/
+
+  # Memoised per root because the answer cannot change while the process lives: a deploy
+  # builds a new release directory and restarts. Without this, every /about request on a
+  # deployment with no REVISION file, and every one in development, would fork a git
+  # subprocess. One consequence worth knowing when checking this by hand: creating a
+  # REVISION file part way through a process's life won't be picked up.
+  #
   # root: exists only so specs can point at a real temporary directory instead of
   # stubbing File.
   def self.short_sha(root: Rails.root)
-    from_revision_file(root) || from_git(root)
+    @short_sha ||= {}
+    key = root.to_s
+    return @short_sha[key] if @short_sha.key?(key)
+
+    @short_sha[key] = from_revision_file(root) || from_git(root)
   end
 
   def self.from_revision_file(root)
     path = root.join("REVISION")
     return unless File.exist?(path)
 
-    File.read(path).strip[0, SHORT_LENGTH].presence
+    sha = File.read(path).strip
+    sha[0, SHORT_LENGTH] if sha.match?(SHA_FORMAT)
   end
   private_class_method :from_revision_file
 
   # Redirecting stderr means this runs via /bin/sh, so a missing git or a directory
   # outside any repository gives us empty output rather than raising Errno::ENOENT.
-  # git -C avoids Dir.chdir, which isn't thread safe.
+  # git -C avoids Dir.chdir, which isn't thread safe. The result is not truncated: git
+  # has already given us the shortest unambiguous form.
   def self.from_git(root)
-    `git -C #{Shellwords.escape(root.to_s)} rev-parse --short=#{SHORT_LENGTH} HEAD 2>/dev/null`.strip.presence
+    sha = `git -C #{Shellwords.escape(root.to_s)} rev-parse --short=#{SHORT_LENGTH} HEAD 2>/dev/null`.strip
+    sha if sha.match?(SHA_FORMAT)
   end
   private_class_method :from_git
 end

--- a/app/views/home/_about.md
+++ b/app/views/home/_about.md
@@ -44,6 +44,8 @@ Email us at [<%= Rails.configuration.contact_email %>](mailto:<%= Rails.configur
 
 You can also read the [OpenAustralia Foundation Blog](https://www.oaf.org.au/blog/), follow us on [Bluesky](https://bsky.app/profile/oaf.org.au) or [Mastodon](https://social.oaf.org.au/@oaf) and [contribute to our work on Github](https://github.com/openaustralia).
 
+<%# The blank line below is load-bearing: Redcarpet needs it to start a new
+    paragraph. Without it the sentence joins the one above. %>
 <% if (version = AppVersion.short_sha) %>
 
 You are using version [<%= version %>](https://github.com/openaustralia/theyvoteforyou/commit/<%= version %>) of <%= inline_project_name %>.

--- a/app/views/home/_about.md
+++ b/app/views/home/_about.md
@@ -43,3 +43,8 @@ You can also [make a donation](https://www.oaf.org.au/donate/) to the OpenAustra
 Email us at [<%= Rails.configuration.contact_email %>](mailto:<%= Rails.configuration.contact_email %>).
 
 You can also read the [OpenAustralia Foundation Blog](https://www.oaf.org.au/blog/), follow us on [Bluesky](https://bsky.app/profile/oaf.org.au) or [Mastodon](https://social.oaf.org.au/@oaf) and [contribute to our work on Github](https://github.com/openaustralia).
+
+<% if (version = AppVersion.short_sha) %>
+
+You are using version [<%= version %>](https://github.com/openaustralia/theyvoteforyou/commit/<%= version %>) of <%= inline_project_name %>.
+<% end %>

--- a/spec/lib/app_version_spec.rb
+++ b/spec/lib/app_version_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+describe AppVersion do
+  describe ".short_sha" do
+    def in_tmp_root
+      Dir.mktmpdir do |dir|
+        yield Pathname.new(dir)
+      end
+    end
+
+    it "shortens the full SHA that Capistrano writes into REVISION" do
+      in_tmp_root do |root|
+        # Capistrano echoes the SHA, so the file ends with a newline
+        File.write(root.join("REVISION"), "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b\n")
+
+        expect(described_class.short_sha(root:)).to eq "1a2b3c4"
+      end
+    end
+
+    it "returns nil outside a git checkout when there is no REVISION file" do
+      in_tmp_root do |root|
+        expect(described_class.short_sha(root:)).to be_nil
+      end
+    end
+
+    it "returns nil when the REVISION file is empty" do
+      in_tmp_root do |root|
+        File.write(root.join("REVISION"), "\n")
+
+        expect(described_class.short_sha(root:)).to be_nil
+      end
+    end
+
+    it "prefers the REVISION file over git, so a release reports what was deployed" do
+      in_tmp_root do |root|
+        system("git", "init", "--quiet", root.to_s, exception: true)
+        File.write(root.join("REVISION"), "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b\n")
+
+        expect(described_class.short_sha(root:)).to eq "1a2b3c4"
+      end
+    end
+
+    it "falls back to git in a development checkout, which has no REVISION file" do
+      expect(described_class.short_sha(root: Rails.root)).to match(/\A[0-9a-f]{7}\z/)
+    end
+  end
+end

--- a/spec/lib/app_version_spec.rb
+++ b/spec/lib/app_version_spec.rb
@@ -5,16 +5,33 @@ require "tmpdir"
 
 describe AppVersion do
   describe ".short_sha" do
+    # Capistrano writes the full 40 character SHA
+    let(:deployed_sha) { "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b" }
+
     def in_tmp_root
       Dir.mktmpdir do |dir|
         yield Pathname.new(dir)
       end
     end
 
+    # A real repository with a real commit, so tests of the git fallback exercise it
+    # rather than silently getting nil from a repository that has no HEAD.
+    def commit_in(root)
+      dir = root.to_s
+      system("git", "init", "--quiet", dir, exception: true)
+      # Local identity and no signing, so this works on a machine with no git config
+      # and in CI, where there is no signing key
+      system("git", "-C", dir, "config", "user.email", "test@example.com", exception: true)
+      system("git", "-C", dir, "config", "user.name", "Test", exception: true)
+      system("git", "-C", dir, "config", "commit.gpgsign", "false", exception: true)
+      system("git", "-C", dir, "commit", "--allow-empty", "--quiet", "-m", "Test", exception: true)
+      `git -C #{dir} rev-parse --short=7 HEAD`.strip
+    end
+
     it "shortens the full SHA that Capistrano writes into REVISION" do
       in_tmp_root do |root|
         # Capistrano echoes the SHA, so the file ends with a newline
-        File.write(root.join("REVISION"), "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b\n")
+        File.write(root.join("REVISION"), "#{deployed_sha}\n")
 
         expect(described_class.short_sha(root:)).to eq "1a2b3c4"
       end
@@ -34,17 +51,32 @@ describe AppVersion do
       end
     end
 
+    it "ignores a REVISION file that doesn't hold a SHA, rather than linking to nothing" do
+      in_tmp_root do |root|
+        File.write(root.join("REVISION"), "Not a SHA\n")
+
+        expect(described_class.short_sha(root:)).to be_nil
+      end
+    end
+
     it "prefers the REVISION file over git, so a release reports what was deployed" do
       in_tmp_root do |root|
-        system("git", "init", "--quiet", root.to_s, exception: true)
-        File.write(root.join("REVISION"), "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b\n")
+        git_sha = commit_in(root)
+        File.write(root.join("REVISION"), "#{deployed_sha}\n")
 
+        # Without this the test would pass on an implementation that checked git first,
+        # because a repository with no commits returns nothing either way
+        expect(git_sha).to match(/\A[0-9a-f]{7}\z/).and(satisfy { |sha| sha != deployed_sha[0, 7] })
         expect(described_class.short_sha(root:)).to eq "1a2b3c4"
       end
     end
 
-    it "falls back to git in a development checkout, which has no REVISION file" do
-      expect(described_class.short_sha(root: Rails.root)).to match(/\A[0-9a-f]{7}\z/)
+    it "falls back to git when there is no REVISION file" do
+      in_tmp_root do |root|
+        git_sha = commit_in(root)
+
+        expect(described_class.short_sha(root:)).to eq git_sha
+      end
     end
   end
 end

--- a/spec/requests/home_controller_spec.rb
+++ b/spec/requests/home_controller_spec.rb
@@ -41,6 +41,16 @@ describe HomeController, type: :request do
     compare_static("/help/faq")
   end
 
+  describe "#about" do
+    it "says which version of the site is running, linked to the commit on GitHub" do
+      get("/about")
+
+      sha = AppVersion.short_sha
+      expect(response.body).to include("You are using version")
+      expect(response.body).to include("https://github.com/openaustralia/theyvoteforyou/commit/#{sha}")
+    end
+  end
+
   describe "#search" do
     it { compare_static("/search") }
 


### PR DESCRIPTION
## What and why

There was no way to tell which revision was running on a server without SSH access. The About page now ends with a sentence naming the deployed commit, linked to GitHub, matching what Planning Alerts does.

- `AppVersion.short_sha` reads the `REVISION` file Capistrano writes into each release, the same file Sentry already reads to tag releases. Failing that it asks git, which covers a development checkout. Failing both it returns `nil` and the sentence is left out entirely, so a deployment that writes no `REVISION` (the Mina-deployed Ukraine site) shows nothing rather than a broken commit link.
- Two things in the Planning Alerts implementation are deliberately not copied: it reads `REVISION` with no existence check, so a missing file raises at boot, and outside production it uses `git describe --always`, which returns a tag description such as `v1.2-3-gabc1234` and would build a commit URL that goes nowhere.
- The sentence uses `inline_project_name`, so it stays correct on the deployments where `config.project_name` is not "They Vote For You".
- Adds a request spec for `/about`. Nothing rendered `_about.md` before, so a broken ERB tag in it would have gone unnoticed.

Resolves #1720

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How this was checked

Rendered `/about` locally and confirmed both code paths produce a real link, not literal markdown:

```html
<p>You are using version <a href="https://github.com/openaustralia/theyvoteforyou/commit/09c4239">09c4239</a> of <em class="project-name">They Vote For You</em>.</p>
```

With a temporary `REVISION` file in place it reported that SHA instead, confirming the deployed-release path. The file was removed afterwards.

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

`bin/rake` passes with 464 examples and 0 failures; `bin/rubocop --parallel` reports no offences across 175 files. `/code-review` has not been run yet, and Actions has not reported at the time of opening.

Two pre-existing problems found along the way, unrelated to this change and worth separate issues:

- `docker-stack/test/docker-compose.yml` can't start on an arm64 Mac. It pins `elasticsearch:6.8.23`, which has no arm64 image, and uses the `journald` log driver, which Docker Desktop on macOS doesn't support.
- `db:prepare` on the test database runs seeds, which die partway through on a missing Elasticsearch and leave rows behind, causing confusing duplicate-primary-key failures on the next run. `db:schema:load` (what CI uses) is unaffected.
