### PR TITLE
Spike: AI-assisted pre-classification of Divisions into Policies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,9 @@ gem "terser"
 # Mamcache client
 gem "dalli", "~>3"
 
+# For calling Bedrock models to classify Divisions against Policies (openaustralia/theyvoteforyou#1716)
+gem "aws-sdk-bedrockruntime"
+
 group :test do
   gem "rspec-activemodel-mocks"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
       execjs (~> 2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1282.0)
+    aws-sdk-bedrockruntime (1.83.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -702,6 +705,7 @@ DEPENDENCIES
   administrate
   attribute-defaults
   autoprefixer-rails
+  aws-sdk-bedrockruntime
   bcrypt_pbkdf (~> 1.1)
   better_errors
   binding_of_caller

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -25,4 +25,11 @@ class AiPolicySuggestion < ApplicationRecord
       error: result.error
     )
   end
+
+  def summary
+    return "Error: #{error}" if error
+
+    subject = match == "existing" ? "policy #{policy_id}" : "new policy I propose"
+    "#{direction == 'for' ? 'For' : 'Against'} #{subject}"
+  end
 end

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -28,6 +28,7 @@ class AiPolicySuggestion < ApplicationRecord
 
   def summary
     return "Error: #{error}" if error
+    return "Error: model response was missing match/direction" if match.nil? || direction.nil?
 
     subject = match == "existing" ? "policy #{policy_id}" : "new policy I propose"
     "#{direction == 'for' ? 'For' : 'Against'} #{subject}"

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Records what one AI model picked for a Division when asked to classify it against our Policies -
+# either an existing Policy match or a proposed new one - along with its reasoning. A draft for a
+# human to review, not a real classification (see DivisionPolicyClassifier, PolicyDivision).
+class AiPolicySuggestion < ApplicationRecord
+  belongs_to :division
+  belongs_to :policy, optional: true
+
+  validates :model, presence: true
+  validates :match, inclusion: { in: %w[existing new] }, allow_nil: true
+  validates :direction, inclusion: { in: %w[for against] }, allow_nil: true
+
+  def self.create_from_result!(division, result)
+    create!(
+      division: division,
+      policy: result.policy,
+      model: result.model,
+      match: result.match,
+      direction: result.direction,
+      proposed_policy_name: result.new_policy_name,
+      proposed_policy_description: result.new_policy_description,
+      reasoning: result.reasoning,
+      raw_response: result.raw,
+      error: result.error
+    )
+  end
+end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -12,6 +12,7 @@ class Division < ApplicationRecord
   has_many :votes, dependent: :destroy
   has_many :policy_divisions, dependent: :destroy
   has_many :policies, through: :policy_divisions
+  has_many :ai_policy_suggestions, dependent: :destroy
   has_many :wiki_motions, -> { order(created_at: :desc) }, inverse_of: :division, dependent: :destroy
   has_and_belongs_to_many :bills
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -7,6 +7,7 @@ class Policy < ApplicationRecord
   has_paper_trail meta: { policy_id: proc(&:id) }
   has_many :policy_divisions, dependent: :destroy
   has_many :divisions, through: :policy_divisions
+  has_many :ai_policy_suggestions, dependent: :nullify
   has_many :policy_person_distances, dependent: :destroy
   has_many :watches, as: :watchable, dependent: :destroy, inverse_of: :watchable
   belongs_to :user

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "aws-sdk-bedrockruntime"
+
+# Asks several Bedrock models to classify a Division against our existing Policies, or propose a
+# new Policy if none fit (spike for openaustralia/theyvoteforyou#1716). Read-only - nothing here
+# writes to the database, every result is a draft for a human to look at.
+class DivisionPolicyClassifier
+  MODELS = {
+    "qwen3-32b" => "qwen.qwen3-32b-v1:0",
+    "deepseek-v3.1" => "deepseek.v3-v1:0",
+    "claude-haiku-4.5" => "anthropic.claude-haiku-4-5-20251001-v1:0"
+  }.freeze
+
+  # None of the models above are available in ap-southeast-2 (our usual region) yet.
+  REGION = "us-east-1"
+
+  EXAMPLES_PER_POLICY = 2
+  MAX_EXAMPLES = 40
+
+  Result = Struct.new(:model, :match, :policy, :direction, :new_policy_name, :new_policy_description,
+                      :reasoning, :raw, :error, keyword_init: true) do
+    def summary
+      return "Error: #{error}" if error
+
+      subject = match == "existing" ? "policy #{policy&.id}" : "new policy I propose"
+      "#{direction == 'for' ? 'For' : 'Against'} #{subject}"
+    end
+  end
+
+  def initialize(division, models: MODELS)
+    @division = division
+    @models = models
+  end
+
+  def classify_with_all_models
+    @models.transform_values { |model_id| classify_with(model_id) }
+  end
+
+  def classify_with(model_id)
+    response = client.converse(
+      model_id: model_id,
+      system: [{ text: system_prompt }],
+      messages: [{ role: "user", content: [{ text: division_prompt }] }],
+      inference_config: { temperature: 0 }
+    )
+    parse(model_id, response.output.message.content.first.text)
+  rescue Aws::Errors::ServiceError => e
+    Result.new(model: model_id, error: e.message)
+  end
+
+  private
+
+  attr_reader :division
+
+  def client
+    @client ||= Aws::BedrockRuntime::Client.new(region: REGION)
+  end
+
+  def system_prompt
+    <<~PROMPT
+      You are helping classify Australian parliamentary divisions (votes) for the TheyVoteForYou
+      website. Each Policy is a stance on an issue; a Division can be linked to a Policy as "for"
+      (a supporter of the policy would vote aye) or "against" (a supporter would vote no).
+
+      Given a division's motion text, decide:
+      - If it clearly relates to one of the existing policies listed below, pick that policy's id
+        and say whether this division represents a vote FOR or AGAINST it.
+      - If none of the existing policies fit, propose a NEW policy: a short name and a
+        one-sentence description, and say whether this division is FOR or AGAINST that new policy.
+
+      Respond with JSON only, no other text, matching this shape exactly:
+      {"match": "existing" or "new", "policy_id": <integer, only if match is "existing">,
+       "new_policy_name": <string, only if match is "new">,
+       "new_policy_description": <string, only if match is "new">,
+       "direction": "for" or "against", "reasoning": "<one sentence>"}
+
+      Existing policies:
+      #{policy_list}
+
+      Divisions already classified, for guidance:
+      #{examples}
+    PROMPT
+  end
+
+  def division_prompt
+    <<~PROMPT
+      Division: #{division.name}
+      House: #{division.full_house_name}
+      Date: #{division.date}
+
+      Motion:
+      #{division.motion}
+    PROMPT
+  end
+
+  def policy_list
+    Policy.published.order(:id).map { |policy| "#{policy.id}. #{policy.name} - #{policy.description}" }.join("\n")
+  end
+
+  def examples
+    lines = []
+    Policy.published.find_each do |policy|
+      break if lines.size >= MAX_EXAMPLES
+
+      policy.policy_divisions.includes(:division).limit(EXAMPLES_PER_POLICY).each do |policy_division|
+        motion = policy_division.division.motion.to_s.truncate(300)
+        lines << "- \"#{motion}\" -> policy #{policy.id} (#{policy.name}), #{direction_word(policy_division.vote)}"
+      end
+    end
+    lines.join("\n")
+  end
+
+  def direction_word(vote)
+    PolicyDivision.vote_without_strong(vote) == "aye" ? "for" : "against"
+  end
+
+  def parse(model_id, text)
+    json = JSON.parse(text.sub(/\A```(?:json)?\n?/, "").sub(/```\s*\z/, "").strip)
+    policy = Policy.find_by(id: json["policy_id"]) if json["match"] == "existing"
+    Result.new(
+      model: model_id,
+      match: json["match"],
+      policy: policy,
+      direction: json["direction"],
+      new_policy_name: json["new_policy_name"],
+      new_policy_description: json["new_policy_description"],
+      reasoning: json["reasoning"],
+      raw: text
+    )
+  rescue JSON::ParserError => e
+    Result.new(model: model_id, error: "Could not parse response: #{e.message}", raw: text)
+  end
+end

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -7,15 +7,13 @@ require "aws-sdk-bedrockruntime"
 # writes to the database, every result is a draft for a human to look at.
 class DivisionPolicyClassifier
   # OAF prefers Australian-hosted infrastructure, so all three run from ap-southeast-2 rather than
-  # the US regions Bedrock more commonly documents:
-  # - Kimi K2.5 and DeepSeek were added to Sydney's open-weight lineup in AWS's Feb 2026 rollout,
-  #   available on-demand like any other foundation model.
-  # - Claude Haiku 4.5 isn't hosted in Sydney directly - it runs via an Australia-pinned
-  #   cross-region inference profile (the "au." prefix) instead of a plain model id. UNVERIFIED:
-  #   confirm this exact profile id against the Bedrock console once signed back into AWS - it's
-  #   inferred from the "us."/"au." inference-profile naming convention, not confirmed directly.
-  # - DeepSeek's model id may need to be deepseek.v3.2 rather than v3.1 for the Sydney rollout -
-  #   also worth confirming against the console.
+  # the US regions Bedrock more commonly documents. Confirmed against `aws bedrock
+  # list-foundation-models`/`list-inference-profiles` for ap-southeast-2:
+  # - Kimi K2.5 and DeepSeek V3.2 are ON_DEMAND foundation models there (added in AWS's Feb 2026
+  #   Sydney open-weight rollout).
+  # - Claude Haiku 4.5 is INFERENCE_PROFILE-only in this region - it isn't hosted in Sydney
+  #   directly, it runs via the Australia-pinned cross-region inference profile
+  #   au.anthropic.claude-haiku-4-5-20251001-v1:0 instead of a plain model id.
   MODELS = {
     "kimi-k2.5" => "moonshotai.kimi-k2.5",
     "deepseek-v3.2" => "deepseek.v3.2",

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -2,17 +2,17 @@
 
 require "aws-sdk-bedrockruntime"
 
-# Asks several Bedrock models to classify a Division against our existing Policies, or propose a
-# new Policy if none fit (spike for openaustralia/theyvoteforyou#1716). Read-only - nothing here
-# writes to the database, every result is a draft for a human to look at.
+# DivisionPolicyClassifier asks several Bedrock models to classify a Division against our existing
+# Policies, or propose a new Policy if none fit (spike for openaustralia/theyvoteforyou#1716). It's
+# read-only: nothing here writes to the database, and every result is a draft for a human to look at.
 class DivisionPolicyClassifier
-  # OAF prefers Australian-hosted infrastructure, so all three run from ap-southeast-2 rather than
-  # the US regions Bedrock more commonly documents. Confirmed against `aws bedrock
-  # list-foundation-models`/`list-inference-profiles` for ap-southeast-2:
-  # - Kimi K2.5 and DeepSeek V3.2 are ON_DEMAND foundation models there (added in AWS's Feb 2026
-  #   Sydney open-weight rollout).
-  # - Claude Haiku 4.5 is INFERENCE_PROFILE-only in this region - it isn't hosted in Sydney
-  #   directly, it runs via the Australia-pinned cross-region inference profile
+  # OAF prefers Australian-hosted infrastructure, so all three models run from ap-southeast-2
+  # instead of the US regions Bedrock more commonly documents. A direct check against `aws bedrock
+  # list-foundation-models`/`list-inference-profiles` for ap-southeast-2 confirmed:
+  # - Kimi K2.5 and DeepSeek V3.2 are ON_DEMAND foundation models there (AWS added them in its
+  #   Feb 2026 Sydney open-weight rollout).
+  # - Claude Haiku 4.5 is INFERENCE_PROFILE-only in this region: Sydney doesn't host it directly,
+  #   so it runs via the Australia-pinned cross-region inference profile
   #   au.anthropic.claude-haiku-4-5-20251001-v1:0 instead of a plain model id.
   MODELS = {
     "kimi-k2.5" => "moonshotai.kimi-k2.5",
@@ -123,7 +123,9 @@ class DivisionPolicyClassifier
   end
 
   def parse(model_id, text)
-    json = JSON.parse(text.sub(/\A```(?:json)?\n?/, "").sub(/```\s*\z/, "").strip)
+    # Models don't reliably follow the "JSON only" instruction - some wrap it in a code fence,
+    # inconsistently, so pull out the object itself rather than trying to strip specific wrappers.
+    json = JSON.parse(text[/\{.*\}/m] || text)
     policy = Policy.find_by(id: json["policy_id"]) if json["match"] == "existing"
     Result.new(
       model: model_id,

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -29,15 +29,18 @@ class DivisionPolicyClassifier
                       :reasoning, :raw, :error, keyword_init: true) do
     def summary
       return "Error: #{error}" if error
+      return "Error: model response was missing match/direction" if match.nil? || direction.nil?
 
       subject = match == "existing" ? "policy #{policy&.id}" : "new policy I propose"
       "#{direction == 'for' ? 'For' : 'Against'} #{subject}"
     end
   end
 
-  def initialize(division, models: MODELS)
+  # client: only for tests, to inject a stubbed Aws::BedrockRuntime::Client
+  def initialize(division, models: MODELS, client: nil)
     @division = division
     @models = models
+    @client = client
   end
 
   def classify_with_all_models

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -6,14 +6,23 @@ require "aws-sdk-bedrockruntime"
 # new Policy if none fit (spike for openaustralia/theyvoteforyou#1716). Read-only - nothing here
 # writes to the database, every result is a draft for a human to look at.
 class DivisionPolicyClassifier
+  # OAF prefers Australian-hosted infrastructure, so all three run from ap-southeast-2 rather than
+  # the US regions Bedrock more commonly documents:
+  # - Kimi K2.5 and DeepSeek were added to Sydney's open-weight lineup in AWS's Feb 2026 rollout,
+  #   available on-demand like any other foundation model.
+  # - Claude Haiku 4.5 isn't hosted in Sydney directly - it runs via an Australia-pinned
+  #   cross-region inference profile (the "au." prefix) instead of a plain model id. UNVERIFIED:
+  #   confirm this exact profile id against the Bedrock console once signed back into AWS - it's
+  #   inferred from the "us."/"au." inference-profile naming convention, not confirmed directly.
+  # - DeepSeek's model id may need to be deepseek.v3.2 rather than v3.1 for the Sydney rollout -
+  #   also worth confirming against the console.
   MODELS = {
-    "qwen3-32b" => "qwen.qwen3-32b-v1:0",
-    "deepseek-v3.1" => "deepseek.v3-v1:0",
-    "claude-haiku-4.5" => "anthropic.claude-haiku-4-5-20251001-v1:0"
+    "kimi-k2.5" => "moonshotai.kimi-k2.5",
+    "deepseek-v3.2" => "deepseek.v3.2",
+    "claude-haiku-4.5" => "au.anthropic.claude-haiku-4-5-20251001-v1:0"
   }.freeze
 
-  # None of the models above are available in ap-southeast-2 (our usual region) yet.
-  REGION = "us-east-1"
+  REGION = "ap-southeast-2"
 
   EXAMPLES_PER_POLICY = 2
   MAX_EXAMPLES = 40

--- a/db/migrate/20260905003244_create_ai_policy_suggestions.rb
+++ b/db/migrate/20260905003244_create_ai_policy_suggestions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateAiPolicySuggestions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_policy_suggestions do |t|
+      t.integer :division_id, null: false
+      t.integer :policy_id
+      t.string :model, null: false
+      t.string :match
+      t.string :direction
+      t.string :proposed_policy_name
+      t.text :proposed_policy_description
+      t.text :reasoning
+      t.text :raw_response
+      t.text :error
+      t.timestamps
+
+      t.index :division_id
+      t.index :policy_id
+      t.index %i[division_id model]
+    end
+  end
+end

--- a/db/migrate/20260905003244_create_ai_policy_suggestions.rb
+++ b/db/migrate/20260905003244_create_ai_policy_suggestions.rb
@@ -17,7 +17,7 @@ class CreateAiPolicySuggestions < ActiveRecord::Migration[8.0]
 
       t.index :division_id
       t.index :policy_id
-      t.index %i[division_id model]
+      t.index %i[division_id model], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
-  create_table "ai_policy_suggestions", force: :cascade do |t|
+  create_table "ai_policy_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "policy_id"
     t.string "model", null: false
@@ -24,12 +24,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.text "error"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["division_id", "model"], name: "index_ai_policy_suggestions_on_division_id_and_model"
+    t.index ["division_id", "model"], name: "index_ai_policy_suggestions_on_division_id_and_model", unique: true
     t.index ["division_id"], name: "index_ai_policy_suggestions_on_division_id"
     t.index ["policy_id"], name: "index_ai_policy_suggestions_on_policy_id"
   end
 
-  create_table "api_statistics", force: :cascade do |t|
+  create_table "api_statistics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "ip_address"
     t.text "query"
     t.text "user_agent"
@@ -38,7 +38,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.datetime "updated_at"
   end
 
-  create_table "bills", force: :cascade do |t|
+  create_table "bills", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "official_id"
     t.text "url"
     t.datetime "created_at"
@@ -46,12 +46,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.text "title"
   end
 
-  create_table "bills_divisions", id: false, force: :cascade do |t|
+  create_table "bills_divisions", id: false, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "bill_id", null: false
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "division_infos", force: :cascade do |t|
+  create_table "division_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "rebellions", null: false
     t.integer "tells", null: false
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["division_id"], name: "division_id"
   end
 
-  create_table "divisions", force: :cascade do |t|
+  create_table "divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date", null: false
     t.integer "number", null: false
     t.string "house", null: false
@@ -97,7 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["number"], name: "division_number"
   end
 
-  create_table "electorates", force: :cascade do |t|
+  create_table "electorates", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 100, null: false
     t.boolean "main_name", null: false
     t.date "from_date", default: "1000-01-01", null: false
@@ -111,14 +111,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["to_date"], name: "to_date"
   end
 
-  create_table "flipper_features", force: :cascade do |t|
+  create_table "flipper_features", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
-  create_table "flipper_gates", force: :cascade do |t|
+  create_table "flipper_gates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
     t.string "value"
@@ -127,7 +127,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "member_infos", force: :cascade do |t|
+  create_table "member_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "member_id", null: false
     t.integer "rebellions", null: false
     t.integer "tells", null: false
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["member_id"], name: "mp_id"
   end
 
-  create_table "members", force: :cascade do |t|
+  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "gid", limit: 100, null: false
     t.text "source_gid", null: false
     t.string "first_name", limit: 100, null: false
@@ -164,7 +164,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["title", "first_name", "last_name", "constituency", "entered_house", "left_house", "house"], name: "title", unique: true
   end
 
-  create_table "offices", force: :cascade do |t|
+  create_table "offices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "dept", null: false
     t.string "position", null: false
     t.string "responsibility", null: false
@@ -176,7 +176,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["person_id"], name: "person"
   end
 
-  create_table "people", force: :cascade do |t|
+  create_table "people", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "small_image_url"
@@ -184,7 +184,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.text "extra_large_image_url"
   end
 
-  create_table "people_distances", force: :cascade do |t|
+  create_table "people_distances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "person1_id", null: false
     t.integer "person2_id", null: false
     t.integer "nvotessame", null: false
@@ -197,7 +197,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["person2_id"], name: "index_people_distances_on_person2_id"
   end
 
-  create_table "policies", force: :cascade do |t|
+  create_table "policies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 100, null: false
     t.integer "user_id", null: false
     t.text "description", null: false
@@ -209,7 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["user_id"], name: "user_id"
   end
 
-  create_table "policy_divisions", force: :cascade do |t|
+  create_table "policy_divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "policy_id", null: false
     t.string "vote", limit: 10, null: false
     t.integer "division_id"
@@ -220,7 +220,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "policy_person_distances", force: :cascade do |t|
+  create_table "policy_person_distances", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "policy_id", null: false
     t.integer "person_id", null: false
     t.integer "nvotessame"
@@ -238,7 +238,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email"
     t.string "encrypted_password", default: "", null: false
@@ -264,7 +264,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", force: :cascade do |t|
+  create_table "versions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -279,7 +279,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "index_versions_on_policy_id"
   end
 
-  create_table "votes", force: :cascade do |t|
+  create_table "votes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "member_id", null: false
     t.string "vote", limit: 10
@@ -293,13 +293,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["vote"], name: "index_votes_on_vote"
   end
 
-  create_table "watches", force: :cascade do |t|
+  create_table "watches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "watchable_id"
     t.string "watchable_type"
     t.integer "user_id"
   end
 
-  create_table "whips", force: :cascade do |t|
+  create_table "whips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.string "party", limit: 200, null: false
     t.integer "aye_votes", null: false
@@ -315,7 +315,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["division_id", "party"], name: "division_id", unique: true
   end
 
-  create_table "wiki_motions", force: :cascade do |t|
+  create_table "wiki_motions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "text_body", null: false
     t.integer "user_id", null: false
     t.integer "division_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,309 +2,325 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_041242) do
-
-  create_table "api_statistics", force: true do |t|
-    t.string   "ip_address"
-    t.text     "query"
-    t.text     "user_agent"
-    t.integer  "user_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "bills", force: true do |t|
-    t.string   "official_id"
-    t.text     "url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text     "title"
-  end
-
-  create_table "bills_divisions", id: false, force: true do |t|
+ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
+  create_table "ai_policy_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
-    t.integer "bill_id",     null: false
+    t.integer "policy_id"
+    t.string "model", null: false
+    t.string "match"
+    t.string "direction"
+    t.string "proposed_policy_name"
+    t.text "proposed_policy_description"
+    t.text "reasoning"
+    t.text "raw_response"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["division_id", "model"], name: "index_ai_policy_suggestions_on_division_id_and_model"
+    t.index ["division_id"], name: "index_ai_policy_suggestions_on_division_id"
+    t.index ["policy_id"], name: "index_ai_policy_suggestions_on_policy_id"
   end
 
-  create_table "delayed_jobs", force: true do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+  create_table "api_statistics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "ip_address"
+    t.text "query"
+    t.text "user_agent"
+    t.integer "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "bills", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "official_id"
+    t.text "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.text "title"
+  end
+
+  create_table "bills_divisions", id: false, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "division_id", null: false
+    t.integer "bill_id", null: false
+  end
+
+  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "division_infos", force: true do |t|
-    t.integer  "division_id",      null: false
-    t.integer  "rebellions",       null: false
-    t.integer  "tells",            null: false
-    t.integer  "turnout",          null: false
-    t.integer  "possible_turnout", null: false
-    t.integer  "aye_majority",     null: false
+  create_table "division_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "division_id", null: false
+    t.integer "rebellions", null: false
+    t.integer "tells", null: false
+    t.integer "turnout", null: false
+    t.integer "possible_turnout", null: false
+    t.integer "aye_majority", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["division_id"], name: "division_id", using: :btree
+    t.index ["division_id"], name: "division_id"
   end
 
-  create_table "divisions", force: true do |t|
-    t.date     "date",                      null: false
-    t.integer  "number",                    null: false
-    t.string   "house",                     null: false
-    t.text     "name",                      null: false
-    t.text     "source_url",                null: false
-    t.text     "debate_url",                null: false
-    t.text     "motion",                    null: false
-    t.string   "clock_time"
-    t.text     "debate_gid",                null: false
+  create_table "divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.date "date", null: false
+    t.integer "number", null: false
+    t.string "house", null: false
+    t.text "name", null: false
+    t.text "source_url", null: false
+    t.text "debate_url", null: false
+    t.text "motion", null: false
+    t.string "clock_time"
+    t.text "debate_gid", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["date", "number", "house"], name: "division_date_2", unique: true, using: :btree
-    t.index ["date"], name: "division_date", using: :btree
-    t.index ["house"], name: "house", using: :btree
-    t.index ["id", "date", "clock_time"], name: "index_divisions_on_id_and_date_and_clock_time", using: :btree
-    t.index ["number"], name: "division_number", using: :btree
+    t.index ["date", "number", "house"], name: "division_date_2", unique: true
+    t.index ["date"], name: "division_date"
+    t.index ["house"], name: "house"
+    t.index ["id", "date", "clock_time"], name: "index_divisions_on_id_and_date_and_clock_time"
+    t.index ["number"], name: "division_number"
   end
 
-  create_table "electorates", force: true do |t|
-    t.string   "name",       limit: 100,                        null: false
-    t.boolean  "main_name",                                     null: false
-    t.date     "from_date",              default: '1000-01-01', null: false
-    t.date     "to_date",                default: '9999-12-31', null: false
-    t.string   "house",                  default: "commons",    null: false
+  create_table "electorates", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", limit: 100, null: false
+    t.boolean "main_name", null: false
+    t.date "from_date", default: "1000-01-01", null: false
+    t.date "to_date", default: "9999-12-31", null: false
+    t.string "house", default: "commons", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["from_date"], name: "from_date", using: :btree
-    t.index ["id", "name"], name: "cons_id", using: :btree
-    t.index ["name"], name: "name", using: :btree
-    t.index ["to_date"], name: "to_date", using: :btree
+    t.index ["from_date"], name: "from_date"
+    t.index ["id", "name"], name: "cons_id"
+    t.index ["name"], name: "name"
+    t.index ["to_date"], name: "to_date"
   end
 
-  create_table "flipper_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "key",        null: false
+  create_table "flipper_features", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["key"], name: "index_flipper_features_on_key", unique: true, using: :btree
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
-  create_table "flipper_gates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "feature_key", null: false
-    t.string   "key",         null: false
-    t.string   "value"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true, using: :btree
+  create_table "flipper_gates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "member_infos", force: true do |t|
-    t.integer  "member_id",      null: false
-    t.integer  "rebellions",     null: false
-    t.integer  "tells",          null: false
-    t.integer  "votes_attended", null: false
-    t.integer  "votes_possible", null: false
-    t.integer  "aye_majority",   null: false
+  create_table "member_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "member_id", null: false
+    t.integer "rebellions", null: false
+    t.integer "tells", null: false
+    t.integer "votes_attended", null: false
+    t.integer "votes_possible", null: false
+    t.integer "aye_majority", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["member_id"], name: "mp_id", using: :btree
+    t.index ["member_id"], name: "mp_id"
   end
 
-  create_table "members", force: true do |t|
-    t.string   "gid",            limit: 100,                        null: false
-    t.text     "source_gid",                                        null: false
-    t.string   "first_name",     limit: 100,                        null: false
-    t.string   "last_name",      limit: 100,                        null: false
-    t.string   "title",          limit: 50,                         null: false
-    t.string   "constituency",   limit: 100,                        null: false
-    t.string   "party",          limit: 100,                        null: false
-    t.string   "house",                                             null: false
-    t.date     "entered_house",              default: '1000-01-01', null: false
-    t.date     "left_house",                 default: '9999-12-31', null: false
-    t.string   "entered_reason", limit: 16,  default: "unknown",    null: false
-    t.string   "left_reason",    limit: 28,  default: "unknown",    null: false
-    t.integer  "person_id"
+  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "gid", limit: 100, null: false
+    t.text "source_gid", null: false
+    t.string "first_name", limit: 100, null: false
+    t.string "last_name", limit: 100, null: false
+    t.string "title", limit: 50, null: false
+    t.string "constituency", limit: 100, null: false
+    t.string "party", limit: 100, null: false
+    t.string "house", null: false
+    t.date "entered_house", default: "1000-01-01", null: false
+    t.date "left_house", default: "9999-12-31", null: false
+    t.string "entered_reason", limit: 16, default: "unknown", null: false
+    t.string "left_reason", limit: 28, default: "unknown", null: false
+    t.integer "person_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["entered_house"], name: "entered_house", using: :btree
-    t.index ["gid"], name: "gid", using: :btree
-    t.index ["house"], name: "house", using: :btree
-    t.index ["left_house"], name: "left_house", using: :btree
-    t.index ["party"], name: "party", using: :btree
-    t.index ["person_id"], name: "person", using: :btree
-    t.index ["title", "first_name", "last_name", "constituency", "entered_house", "left_house", "house"], name: "title", unique: true, using: :btree
+    t.index ["entered_house"], name: "entered_house"
+    t.index ["gid"], name: "gid"
+    t.index ["house"], name: "house"
+    t.index ["left_house"], name: "left_house"
+    t.index ["party"], name: "party"
+    t.index ["person_id"], name: "person"
+    t.index ["title", "first_name", "last_name", "constituency", "entered_house", "left_house", "house"], name: "title", unique: true
   end
 
-  create_table "offices", force: true do |t|
-    t.string   "dept",                                  null: false
-    t.string   "position",                              null: false
-    t.string   "responsibility",                        null: false
-    t.date     "from_date",      default: '1000-01-01', null: false
-    t.date     "to_date",        default: '9999-12-31', null: false
-    t.integer  "person_id"
+  create_table "offices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "dept", null: false
+    t.string "position", null: false
+    t.string "responsibility", null: false
+    t.date "from_date", default: "1000-01-01", null: false
+    t.date "to_date", default: "9999-12-31", null: false
+    t.integer "person_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["person_id"], name: "person", using: :btree
+    t.index ["person_id"], name: "person"
   end
 
-  create_table "people", force: true do |t|
+  create_table "people", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "small_image_url"
-    t.text     "large_image_url"
+    t.text "small_image_url"
+    t.text "large_image_url"
     t.text "extra_large_image_url"
   end
 
-  create_table "people_distances", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "people_distances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "person1_id", null: false
     t.integer "person2_id", null: false
     t.integer "nvotessame", null: false
     t.integer "nvotesdiffer", null: false
     t.float "distance_b", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["person1_id", "person2_id"], name: "index_people_distances_on_person1_id_and_person2_id", unique: true
     t.index ["person1_id"], name: "index_people_distances_on_person1_id"
     t.index ["person2_id"], name: "index_people_distances_on_person2_id"
   end
 
-  create_table "policies", force: true do |t|
-    t.string   "name",        limit: 100, null: false
-    t.integer  "user_id",                 null: false
-    t.text     "description",             null: false
-    t.integer  "private",     limit: 1,   null: false
+  create_table "policies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", limit: 100, null: false
+    t.integer "user_id", null: false
+    t.text "description", null: false
+    t.integer "private", limit: 1, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["id", "name", "user_id"], name: "dream_id", unique: true, using: :btree
-    t.index ["user_id"], name: "user_id", using: :btree
+    t.index ["id", "name", "user_id"], name: "dream_id", unique: true
     t.index ["name"], name: "index_policies_on_name", unique: true
+    t.index ["user_id"], name: "user_id"
   end
 
-  create_table "policy_divisions", force: true do |t|
-    t.integer  "policy_id",              null: false
-    t.string   "vote",        limit: 10, null: false
-    t.integer  "division_id"
+  create_table "policy_divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "policy_id", null: false
+    t.string "vote", limit: 10, null: false
+    t.integer "division_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["division_id", "policy_id"], name: "index_policy_divisions_on_division_id_and_policy_id", unique: true, using: :btree
-    t.index ["division_id"], name: "index_policy_divisions_on_division_id", using: :btree
-    t.index ["policy_id"], name: "dream_id", using: :btree
+    t.index ["division_id", "policy_id"], name: "index_policy_divisions_on_division_id_and_policy_id", unique: true
+    t.index ["division_id"], name: "index_policy_divisions_on_division_id"
+    t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "policy_person_distances", force: true do |t|
-    t.integer  "policy_id",                     null: false
-    t.integer  "person_id",                     null: false
-    t.integer  "nvotessame"
-    t.integer  "nvotessamestrong"
-    t.integer  "nvotesdiffer"
-    t.integer  "nvotesdifferstrong"
-    t.integer  "nvotesabsent"
-    t.integer  "nvotesabsentstrong"
-    t.float    "distance_a",         limit: 24
-    t.float    "distance_b",         limit: 24
+  create_table "policy_person_distances", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "policy_id", null: false
+    t.integer "person_id", null: false
+    t.integer "nvotessame"
+    t.integer "nvotessamestrong"
+    t.integer "nvotesdiffer"
+    t.integer "nvotesdifferstrong"
+    t.integer "nvotesabsent"
+    t.integer "nvotesabsentstrong"
+    t.float "distance_a"
+    t.float "distance_b"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["person_id"], name: "person", using: :btree
-    t.index ["policy_id", "person_id"], name: "dream_id_2", unique: true, using: :btree
-    t.index ["policy_id"], name: "dream_id", using: :btree
+    t.index ["person_id"], name: "person"
+    t.index ["policy_id", "person_id"], name: "dream_id_2", unique: true
+    t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "email"
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "confirmation_token"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
+    t.string "unconfirmed_email"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "api_key"
-    t.boolean  "admin",                                   default: false, null: false
+    t.string "api_key"
+    t.boolean "admin", default: false, null: false
     t.boolean "staff", default: false, null: false
-    t.index ["api_key"], name: "index_users_on_api_key", unique: true, using: :btree
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["api_key"], name: "index_users_on_api_key", unique: true
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", force: true do |t|
-    t.string   "item_type",      null: false
-    t.integer  "item_id",        null: false
-    t.string   "event",          null: false
-    t.string   "whodunnit"
-    t.text     "object"
+  create_table "versions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
     t.datetime "created_at"
-    t.integer  "policy_id"
-    t.text     "object_changes"
-    t.integer  "division_id"
-    t.index ["division_id"], name: "index_versions_on_division_id", using: :btree
-    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
-    t.index ["policy_id"], name: "index_versions_on_policy_id", using: :btree
+    t.integer "policy_id"
+    t.text "object_changes"
+    t.integer "division_id"
+    t.index ["division_id"], name: "index_versions_on_division_id"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["policy_id"], name: "index_versions_on_policy_id"
   end
 
-  create_table "votes", force: true do |t|
-    t.integer  "division_id",                            null: false
-    t.integer  "member_id",                              null: false
-    t.string   "vote",        limit: 10
-    t.boolean  "teller",                 default: false, null: false
+  create_table "votes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "division_id", null: false
+    t.integer "member_id", null: false
+    t.string "vote", limit: 10
+    t.boolean "teller", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["division_id", "member_id"], name: "division_id_2", unique: true, using: :btree
-    t.index ["division_id"], name: "division_id", using: :btree
-    t.index ["member_id"], name: "mp_id", using: :btree
-    t.index ["teller"], name: "index_votes_on_teller", using: :btree
-    t.index ["vote"], name: "index_votes_on_vote", using: :btree
+    t.index ["division_id", "member_id"], name: "division_id_2", unique: true
+    t.index ["division_id"], name: "division_id"
+    t.index ["member_id"], name: "mp_id"
+    t.index ["teller"], name: "index_votes_on_teller"
+    t.index ["vote"], name: "index_votes_on_vote"
   end
 
-  create_table "watches", force: true do |t|
+  create_table "watches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "watchable_id"
-    t.string  "watchable_type"
+    t.string "watchable_type"
     t.integer "user_id"
   end
 
-  create_table "whips", force: true do |t|
-    t.integer  "division_id",                  null: false
-    t.string   "party",            limit: 200, null: false
-    t.integer  "aye_votes",                    null: false
-    t.integer  "aye_tells",                    null: false
-    t.integer  "no_votes",                     null: false
-    t.integer  "no_tells",                     null: false
-    t.integer  "both_votes",                   null: false
-    t.integer  "abstention_votes",             null: false
-    t.integer  "possible_votes",               null: false
-    t.string   "whip_guess",       limit: 10,  null: false
+  create_table "whips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "division_id", null: false
+    t.string "party", limit: 200, null: false
+    t.integer "aye_votes", null: false
+    t.integer "aye_tells", null: false
+    t.integer "no_votes", null: false
+    t.integer "no_tells", null: false
+    t.integer "both_votes", null: false
+    t.integer "abstention_votes", null: false
+    t.integer "possible_votes", null: false
+    t.string "whip_guess", limit: 10, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["division_id", "party"], name: "division_id", unique: true, using: :btree
+    t.index ["division_id", "party"], name: "division_id", unique: true
   end
 
-  create_table "wiki_motions", force: true do |t|
-    t.text     "text_body",   null: false
-    t.integer  "user_id",     null: false
-    t.integer  "division_id"
+  create_table "wiki_motions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "text_body", null: false
+    t.integer "user_id", null: false
+    t.integer "division_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["division_id"], name: "index_wiki_motions_on_division_id", using: :btree
+    t.index ["division_id"], name: "index_wiki_motions_on_division_id"
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
-  create_table "ai_policy_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "ai_policy_suggestions", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "policy_id"
     t.string "model", null: false
@@ -29,7 +29,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "index_ai_policy_suggestions_on_policy_id"
   end
 
-  create_table "api_statistics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "api_statistics", force: :cascade do |t|
     t.string "ip_address"
     t.text "query"
     t.text "user_agent"
@@ -38,7 +38,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.datetime "updated_at"
   end
 
-  create_table "bills", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "bills", force: :cascade do |t|
     t.string "official_id"
     t.text "url"
     t.datetime "created_at"
@@ -46,12 +46,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.text "title"
   end
 
-  create_table "bills_divisions", id: false, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "bills_divisions", id: false, force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "bill_id", null: false
   end
 
-  create_table "delayed_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "division_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "division_infos", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "rebellions", null: false
     t.integer "tells", null: false
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["division_id"], name: "division_id"
   end
 
-  create_table "divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "divisions", force: :cascade do |t|
     t.date "date", null: false
     t.integer "number", null: false
     t.string "house", null: false
@@ -97,7 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["number"], name: "division_number"
   end
 
-  create_table "electorates", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "electorates", force: :cascade do |t|
     t.string "name", limit: 100, null: false
     t.boolean "main_name", null: false
     t.date "from_date", default: "1000-01-01", null: false
@@ -111,14 +111,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["to_date"], name: "to_date"
   end
 
-  create_table "flipper_features", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
-  create_table "flipper_gates", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
     t.string "value"
@@ -127,7 +127,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "member_infos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "member_infos", force: :cascade do |t|
     t.integer "member_id", null: false
     t.integer "rebellions", null: false
     t.integer "tells", null: false
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["member_id"], name: "mp_id"
   end
 
-  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "members", force: :cascade do |t|
     t.string "gid", limit: 100, null: false
     t.text "source_gid", null: false
     t.string "first_name", limit: 100, null: false
@@ -164,7 +164,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["title", "first_name", "last_name", "constituency", "entered_house", "left_house", "house"], name: "title", unique: true
   end
 
-  create_table "offices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "offices", force: :cascade do |t|
     t.string "dept", null: false
     t.string "position", null: false
     t.string "responsibility", null: false
@@ -176,7 +176,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["person_id"], name: "person"
   end
 
-  create_table "people", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "people", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "small_image_url"
@@ -184,7 +184,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.text "extra_large_image_url"
   end
 
-  create_table "people_distances", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "people_distances", force: :cascade do |t|
     t.integer "person1_id", null: false
     t.integer "person2_id", null: false
     t.integer "nvotessame", null: false
@@ -197,7 +197,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["person2_id"], name: "index_people_distances_on_person2_id"
   end
 
-  create_table "policies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "policies", force: :cascade do |t|
     t.string "name", limit: 100, null: false
     t.integer "user_id", null: false
     t.text "description", null: false
@@ -209,7 +209,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["user_id"], name: "user_id"
   end
 
-  create_table "policy_divisions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "policy_divisions", force: :cascade do |t|
     t.integer "policy_id", null: false
     t.string "vote", limit: 10, null: false
     t.integer "division_id"
@@ -220,7 +220,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "policy_person_distances", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "policy_person_distances", force: :cascade do |t|
     t.integer "policy_id", null: false
     t.integer "person_id", null: false
     t.integer "nvotessame"
@@ -238,7 +238,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "dream_id"
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email"
     t.string "encrypted_password", default: "", null: false
@@ -264,7 +264,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "versions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
@@ -279,7 +279,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["policy_id"], name: "index_versions_on_policy_id"
   end
 
-  create_table "votes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "votes", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "member_id", null: false
     t.string "vote", limit: 10
@@ -293,13 +293,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["vote"], name: "index_votes_on_vote"
   end
 
-  create_table "watches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "watches", force: :cascade do |t|
     t.integer "watchable_id"
     t.string "watchable_type"
     t.integer "user_id"
   end
 
-  create_table "whips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "whips", force: :cascade do |t|
     t.integer "division_id", null: false
     t.string "party", limit: 200, null: false
     t.integer "aye_votes", null: false
@@ -315,7 +315,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
     t.index ["division_id", "party"], name: "division_id", unique: true
   end
 
-  create_table "wiki_motions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "wiki_motions", force: :cascade do |t|
     t.text "text_body", null: false
     t.integer "user_id", null: false
     t.integer "division_id"

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -22,23 +22,31 @@ namespace :ai do
   end
 
   desc "Ask several Bedrock models to classify a Division against existing Policies, saving each " \
-       "as an AiPolicySuggestion (spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
+       "as an AiPolicySuggestion - skips any model already saved for this Division " \
+       "(spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
   task classify_division: :environment do
     division_id = ENV.fetch("DIVISION_ID") { abort "Usage: rake ai:classify_division DIVISION_ID=123" }
     division = Division.find(division_id)
+    classifier = DivisionPolicyClassifier.new(division)
 
     puts "Division ##{division.id}: #{division.name}"
     puts division.motion.to_s.truncate(200)
     puts
 
-    DivisionPolicyClassifier.new(division).classify_with_all_models.each do |label, result|
-      AiPolicySuggestion.create_from_result!(division, result)
+    DivisionPolicyClassifier::MODELS.each do |label, model_id|
+      suggestion = AiPolicySuggestion.find_by(division: division, model: model_id)
+      if suggestion
+        puts "== #{label} (already classified, skipping) =="
+      else
+        result = classifier.classify_with(model_id)
+        suggestion = AiPolicySuggestion.create_from_result!(division, result)
+        puts "== #{label} =="
+      end
 
-      puts "== #{label} =="
-      puts result.summary
-      puts "  Policy: #{result.policy.name} - #{result.policy.description}" if result.match == "existing" && result.policy
-      puts "  Proposed: #{result.new_policy_name} - #{result.new_policy_description}" if result.match == "new"
-      puts "  Reasoning: #{result.reasoning}" if result.reasoning
+      puts suggestion.summary
+      puts "  Policy: #{suggestion.policy.name} - #{suggestion.policy.description}" if suggestion.match == "existing" && suggestion.policy
+      puts "  Proposed: #{suggestion.proposed_policy_name} - #{suggestion.proposed_policy_description}" if suggestion.match == "new"
+      puts "  Reasoning: #{suggestion.reasoning}" if suggestion.reasoning
       puts
     end
   end

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -21,8 +21,8 @@ namespace :ai do
     puts "Imported #{policies.size} policies (#{created} created, #{updated} updated)"
   end
 
-  desc "Ask several Bedrock models to classify a Division against existing Policies " \
-       "(spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
+  desc "Ask several Bedrock models to classify a Division against existing Policies, saving each " \
+       "as an AiPolicySuggestion (spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
   task classify_division: :environment do
     division_id = ENV.fetch("DIVISION_ID") { abort "Usage: rake ai:classify_division DIVISION_ID=123" }
     division = Division.find(division_id)
@@ -32,6 +32,8 @@ namespace :ai do
     puts
 
     DivisionPolicyClassifier.new(division).classify_with_all_models.each do |label, result|
+      AiPolicySuggestion.create_from_result!(division, result)
+
       puts "== #{label} =="
       puts result.summary
       puts "  Policy: #{result.policy.name} - #{result.policy.description}" if result.match == "existing" && result.policy

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 namespace :ai do
+  desc "Import Policies from theyvoteforyou.org.au's own /api/v1/policies.json output, for local " \
+       "dev data (spike, openaustralia/theyvoteforyou#1716). FILE=<path to saved JSON> required."
+  task import_policies: :environment do
+    file = ENV.fetch("FILE") { abort "Usage: rake ai:import_policies FILE=/path/to/policies.json" }
+    owner = User.first || abort("Need at least one User in the dev database to own imported Policies")
+
+    policies = JSON.parse(File.read(file))
+    created = 0
+    updated = 0
+    policies.each do |attrs|
+      policy = Policy.find_or_initialize_by(name: attrs["name"])
+      policy.user ||= owner
+      policy.description = attrs["description"]
+      policy.status = attrs["provisional"] ? :provisional : :published
+      policy.new_record? ? created += 1 : updated += 1
+      policy.save!
+    end
+    puts "Imported #{policies.size} policies (#{created} created, #{updated} updated)"
+  end
+
   desc "Ask several Bedrock models to classify a Division against existing Policies " \
        "(spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
   task classify_division: :environment do

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :ai do
+  desc "Ask several Bedrock models to classify a Division against existing Policies " \
+       "(spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
+  task classify_division: :environment do
+    division_id = ENV.fetch("DIVISION_ID") { abort "Usage: rake ai:classify_division DIVISION_ID=123" }
+    division = Division.find(division_id)
+
+    puts "Division ##{division.id}: #{division.name}"
+    puts division.motion.to_s.truncate(200)
+    puts
+
+    DivisionPolicyClassifier.new(division).classify_with_all_models.each do |label, result|
+      puts "== #{label} =="
+      puts result.summary
+      puts "  Proposed: #{result.new_policy_name} - #{result.new_policy_description}" if result.match == "new"
+      puts "  Reasoning: #{result.reasoning}" if result.reasoning
+      puts
+    end
+  end
+end

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -34,6 +34,7 @@ namespace :ai do
     DivisionPolicyClassifier.new(division).classify_with_all_models.each do |label, result|
       puts "== #{label} =="
       puts result.summary
+      puts "  Policy: #{result.policy.name} - #{result.policy.description}" if result.match == "existing" && result.policy
       puts "  Proposed: #{result.new_policy_name} - #{result.new_policy_description}" if result.match == "new"
       puts "  Reasoning: #{result.reasoning}" if result.reasoning
       puts

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+# Keep this in sync with .ruby-version.
+[tools]
+ruby = "3.4.4"

--- a/spec/factories/ai_policy_suggestions.rb
+++ b/spec/factories/ai_policy_suggestions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ai_policy_suggestion do
+    division
+    policy
+    model { "test.model-v1:0" }
+    match { "existing" }
+    direction { "for" }
+    reasoning { "because the test says so" }
+  end
+end

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AiPolicySuggestion do
+  describe "validations" do
+    it "requires a model" do
+      suggestion = build(:ai_policy_suggestion, model: nil)
+      expect(suggestion).not_to be_valid
+    end
+
+    it "allows match and direction to be nil, for a failed classification" do
+      suggestion = build(:ai_policy_suggestion, match: nil, direction: nil)
+      expect(suggestion).to be_valid
+    end
+
+    it "rejects a match value that isn't existing or new" do
+      suggestion = build(:ai_policy_suggestion, match: "sort-of")
+      expect(suggestion).not_to be_valid
+    end
+
+    it "rejects a direction value that isn't for or against" do
+      suggestion = build(:ai_policy_suggestion, direction: "sideways")
+      expect(suggestion).not_to be_valid
+    end
+  end
+
+  describe ".create_from_result!" do
+    it "maps every field from the classifier's result" do
+      division = create(:division)
+      policy = create(:policy)
+      result = DivisionPolicyClassifier::Result.new(
+        model: "test.model-v1:0",
+        match: "existing",
+        policy: policy,
+        direction: "for",
+        reasoning: "because",
+        raw: '{"match": "existing"}'
+      )
+
+      suggestion = described_class.create_from_result!(division, result)
+
+      expect(suggestion.division).to eq division
+      expect(suggestion.policy).to eq policy
+      expect(suggestion.model).to eq "test.model-v1:0"
+      expect(suggestion.match).to eq "existing"
+      expect(suggestion.direction).to eq "for"
+      expect(suggestion.reasoning).to eq "because"
+      expect(suggestion.raw_response).to eq '{"match": "existing"}'
+    end
+  end
+
+  describe "#summary" do
+    it "names the matched policy and direction" do
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", policy: build(:policy, id: 42))
+      expect(suggestion.summary).to eq "For policy 42"
+    end
+
+    it "says a new policy was proposed" do
+      suggestion = build(:ai_policy_suggestion, match: "new", direction: "against", policy: nil)
+      expect(suggestion.summary).to eq "Against new policy I propose"
+    end
+
+    it "reports the stored error instead of guessing" do
+      suggestion = build(:ai_policy_suggestion, error: "boom")
+      expect(suggestion.summary).to eq "Error: boom"
+    end
+
+    it "reports an error rather than a misleading summary when match/direction are missing" do
+      suggestion = build(:ai_policy_suggestion, match: nil, direction: nil, error: nil)
+      expect(suggestion.summary).to eq "Error: model response was missing match/direction"
+    end
+  end
+end

--- a/spec/services/division_policy_classifier_spec.rb
+++ b/spec/services/division_policy_classifier_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DivisionPolicyClassifier do
+  let(:division) { create(:division, motion: "That this House bans the thing") }
+  let(:stubbed_client) { Aws::BedrockRuntime::Client.new(stub_responses: true) }
+  let(:models) { { "test-model" => "test.model-v1:0" } }
+  let(:classifier) { described_class.new(division, models: models, client: stubbed_client) }
+
+  # The stub validator requires the full response shape even though our code only reads
+  # output.message.content - stop_reason/usage/metrics are irrelevant to the tests but mandatory here.
+  def converse_response(text)
+    {
+      output: { message: { role: "assistant", content: [{ text: text }] } },
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      metrics: { latency_ms: 1 }
+    }
+  end
+
+  def stub_converse_text(text)
+    stubbed_client.stub_responses(:converse, converse_response(text))
+  end
+
+  describe "#classify_with" do
+    it "matches an existing policy" do
+      policy = create(:policy)
+      stub_converse_text(%({"match": "existing", "policy_id": #{policy.id}, "direction": "for", "reasoning": "because"}))
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.match).to eq "existing"
+      expect(result.policy).to eq policy
+      expect(result.direction).to eq "for"
+      expect(result.reasoning).to eq "because"
+      expect(result.error).to be_nil
+      expect(result.summary).to eq "For policy #{policy.id}"
+    end
+
+    it "proposes a new policy when none fit" do
+      stub_converse_text(<<~JSON)
+        {"match": "new", "new_policy_name": "banning things", "new_policy_description": "the government should ban things", "direction": "against", "reasoning": "no existing policy covers this"}
+      JSON
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.match).to eq "new"
+      expect(result.new_policy_name).to eq "banning things"
+      expect(result.new_policy_description).to eq "the government should ban things"
+      expect(result.direction).to eq "against"
+      expect(result.summary).to eq "Against new policy I propose"
+    end
+
+    it "extracts the JSON even when a model wraps it in a code fence" do
+      policy = create(:policy)
+      stub_converse_text(<<~TEXT)
+        ```json
+        {"match": "existing", "policy_id": #{policy.id}, "direction": "against", "reasoning": "wrapped in a fence"}
+        ```
+      TEXT
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.match).to eq "existing"
+      expect(result.policy).to eq policy
+    end
+
+    it "records an error, rather than a misleading summary, when the response is missing match/direction" do
+      stub_converse_text(%({"reasoning": "the model didn't return what we asked for"}))
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.error).to be_nil
+      expect(result.summary).to eq "Error: model response was missing match/direction"
+    end
+
+    it "records an error when the response isn't valid JSON" do
+      stub_converse_text("sorry, I can't help with that")
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.error).to include("Could not parse response")
+      expect(result.summary).to eq "Error: #{result.error}"
+    end
+
+    it "records an error when Bedrock itself fails, rather than raising" do
+      stubbed_client.stub_responses(:converse, "ServiceUnavailableException")
+
+      result = classifier.classify_with("test.model-v1:0")
+
+      expect(result.model).to eq "test.model-v1:0"
+      expect(result.error).to be_present
+    end
+
+    it "only includes published policies in the prompt, not provisional ones" do
+      published = create(:policy, name: "a published policy")
+      provisional = create(:provisional_policy, name: "a provisional policy")
+
+      prompt = classifier.send(:system_prompt)
+
+      expect(prompt).to include(published.name)
+      expect(prompt).not_to include(provisional.name)
+    end
+  end
+
+  describe "#classify_with_all_models" do
+    it "asks every configured model and keys the results by label" do
+      models = { "model-a" => "a.model-v1:0", "model-b" => "b.model-v1:0" }
+      classifier = described_class.new(division, models: models, client: stubbed_client)
+      stub_converse_text(%({"match": "new", "direction": "for", "reasoning": "x"}))
+
+      results = classifier.classify_with_all_models
+
+      expect(results.keys).to contain_exactly("model-a", "model-b")
+      expect(results.values).to all(have_attributes(match: "new"))
+    end
+  end
+end


### PR DESCRIPTION
## What and why

This PR is a spike for #1716: it prototypes using Amazon Bedrock to pre-classify Divisions into Policies from our existing expert-labelled Policy/Division data, surfacing predictions as drafts for human admin review rather than auto-publishing.

- `DivisionPolicyClassifier` asks three Bedrock models - Kimi K2.5, DeepSeek V3.2, and Claude Haiku 4.5 - to classify a division against our existing Policies (with a handful of already-classified divisions per policy as few-shot examples), or propose a new Policy if none fit. It's a pure classifier: it calls Bedrock and returns results, and writes nothing to the database itself.
- The new `AiPolicySuggestion` model records what each model actually picked - an existing Policy match (with direction) or a proposed new one - plus its reasoning and the raw response, kept as a separate table from `PolicyDivision` (the real, human-curated classifications) so drafts are never confused with verified data.
- `rake ai:classify_division DIVISION_ID=<id>` ties the two together: it asks each model, saves an `AiPolicySuggestion` per model, and prints the result - "For policy N" / "Against policy N" / "For/against new policy I propose", the matched or proposed policy's name and description, and the model's reasoning. It skips a model entirely (no Bedrock call) if a suggestion for that division/model pair already exists.
- `rake ai:import_policies FILE=<path>` loads a saved `/api/v1/policies.json` response into the local dev `Policy` table, so the classifier has real policy names/descriptions to work with instead of near-empty seed data. I've already run it against production's real data: it imported 368 policies, 279 published.
- All three models run from `ap-southeast-2` (Sydney) rather than the more commonly-documented US regions, since OAF prefers Australian-hosted infrastructure. Kimi K2.5 and DeepSeek V3.2 are `ON_DEMAND` there; Claude Haiku 4.5 runs via its Australia-pinned cross-region inference profile instead. I confirmed all three against the live Bedrock API, not just docs. The classifier needs the IAM credentials from [openaustralia/infrastructure#747](https://github.com/openaustralia/infrastructure/pull/747) (awaiting approval) in `.envrc` to actually call Bedrock - or a personal Bedrock API key (`AWS_BEARER_TOKEN_BEDROCK`) for quick testing, which is how I've verified real responses already.

Before this can say anything about real accuracy, we still need real Division motion text with existing Policy links - the public API's bulk endpoint doesn't expose that (only its per-division `show` endpoint does, under `"summary"`). The plan is a direct production DB query for that; not done yet.

This branch was cut from `main` before [#1657](https://github.com/openaustralia/theyvoteforyou/pull/1657) (the devcontainer/hybrid dev environment) merged, so `main` doesn't have `make dev-hybrid` etc. That isn't a blocker though, since the docker services and `.envrc`/`database.yml` are all outside git and work regardless of branch.

## Type of change

- [x] New feature (spike/prototype, not production-ready)

## How this was checked

- [x] Ran `bundle exec rubocop` on all new/changed files - clean
- [x] Verified real Bedrock responses against known divisions using a personal API key - all three models return sensible, parseable classifications; `AiPolicySuggestion` rows persist correctly; the skip-if-already-classified logic avoids a repeat call
- [x] Fixed a CI failure this branch caused: `db:migrate` locally (MySQL 8.4) re-dumped `schema.rb` with a MySQL-8-only collation on every table, which broke CI's `mysql:5.7` service entirely - stripped it back out (moot now that #1723 moved CI to MySQL 8.4 to match production)
- [x] Ran the automated tests: added specs for `DivisionPolicyClassifier` and `AiPolicySuggestion` with a stubbed Bedrock client (no real API calls) - covers existing-Policy matches, new-Policy proposals, the code-fence JSON extraction fix, invalid JSON, a Bedrock service error, and that only published Policies reach the prompt. Full suite: 475 examples, 1 pre-existing unrelated failure (a local Selenium/Chrome sandbox issue)
- [x] Ran `/code-review` (or equivalent): Sentry's automated PR review caught a real bug - `summary` fell through to a fabricated "Against new policy I propose" when a model's JSON was valid but missing `match`/`direction`. Fixed in both places it appeared, replied on the review thread, added regression specs
- [x] GitHub Actions tests: passing (see #1723 for the MySQL-version fix that was blocking this)
- [ ] Documentation updated - not needed, this is a spike with no user-facing docs yet

Assisted-by: Claude Code:claude-sonnet-5