### PR TITLE
CI: test against MySQL 8.4 to match production

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -10,10 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
-      # We're using mysql 5.7 in production currently
-      # TODO: We need to upgrade this in production because it's costing us extra AWS "support" dollars
+      # Matches production, which is RDS MySQL 8.4 (see infrastructure repo's terraform/database.tf)
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         ports:
           - "3306:3306"
         env:


### PR DESCRIPTION
## What and why

Closes #1707.

`.github/workflows/rubyonrails.yml` pinned the MySQL service to `mysql:5.7` with a comment saying that's what production runs. Production is actually RDS MySQL 8.4 (`terraform/database.tf` in the infrastructure repo) - the comment was stale, left over from before #1656's 8.0 → 8.4 upgrade. #1707 asked for 8.0; I've gone with 8.4 instead since that's what production is on right now, not just "8.x" generically.

Done independently of #1702 (the Ubuntu 26.04 upgrade), per #1707's own request, so any MySQL-version failures can't get confused with OS-version ones later.

## Type of change

- [x] Bug fix

## How this was checked

- [x] Verified locally against MySQL 8.4 (this machine's dev database): `bin/rails db:schema:load` then `bin/rake` - 457 of 458 examples pass
- [x] The one failure (`spec/features/edit_division_spec.rb:13`) is a Selenium/Chrome launch error ("cannot kill Chrome", "DevToolsActivePort file doesn't exist") local to my sandbox, unrelated to the database - no SQL-mode, collation, or `ONLY_FULL_GROUP_BY`-style breakage
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

Assisted-by: Claude Code:claude-sonnet-5