### PR TITLE
Run CI on PRs for branches, push only for main

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,7 +5,10 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What and why

`.github/workflows/rubyonrails.yml` had `on: [push, pull_request]`, so every push to a branch with an open PR ran the workflow twice - once for the push, once for the PR sync - doubling CI time and cost for no extra signal. Now it only runs on `push` to `main` (post-merge) and on `pull_request` (covers every branch with an open PR, regardless of which branch).

## Type of change

- [x] Bug fix

## How this was checked

- [x] Validated the YAML parses correctly
- [ ] Checked the affected area on my own or a staging system
- [ ] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

Assisted-by: Claude Code:claude-sonnet-5