### PR TITLE
Import Policies without depending on Elasticsearch

### DIFF
--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -10,13 +10,17 @@ namespace :ai do
     policies = JSON.parse(File.read(file))
     created = 0
     updated = 0
-    policies.each do |attrs|
-      policy = Policy.find_or_initialize_by(name: attrs["name"])
-      policy.user ||= owner
-      policy.description = attrs["description"]
-      policy.status = attrs["provisional"] ? :provisional : :published
-      policy.new_record? ? created += 1 : updated += 1
-      policy.save!
+    # This is a plain data import for the classifier to read - it has nothing to do with search,
+    # so it shouldn't depend on Elasticsearch being reachable (openaustralia/theyvoteforyou#1728).
+    Searchkick.callbacks(false) do
+      policies.each do |attrs|
+        policy = Policy.find_or_initialize_by(name: attrs["name"])
+        policy.user ||= owner
+        policy.description = attrs["description"]
+        policy.status = attrs["provisional"] ? :provisional : :published
+        policy.new_record? ? created += 1 : updated += 1
+        policy.save!
+      end
     end
     puts "Imported #{policies.size} policies (#{created} created, #{updated} updated)"
   end


### PR DESCRIPTION
## What and why

`rake ai:import_policies` calls `policy.save!` per record, which triggers Searchkick's `after_commit` reindex callback. On staging, where Elasticsearch isn't reachable (#1728), the very first save raised `Faraday::ConnectionFailed` and aborted the whole import, unrescued - the run reported success-shaped output but likely imported 0 policies (found while actually trying to import onto staging for testing).

This task only exists to give the AI classifier real Policy text to read (openaustralia/theyvoteforyou#1716) - it has nothing to do with search, so it shouldn't depend on Elasticsearch being up. Wrapped the import in `Searchkick.callbacks(false)` to skip reindexing during the bulk import - search will just be stale for these records until the next full reindex, same as any other bulk data load.

## Type of change

- [x] Bug fix

## How this was checked

- [x] Ran `bundle exec rubocop` - clean
- [x] Re-ran the import locally: 368 policies imported/updated successfully
- [x] Ran the existing `DivisionPolicyClassifier`/`AiPolicySuggestion` specs - still passing
- [ ] Ran the automated tests (no test coverage for this specific rake task's Searchkick interaction - low value to add given it's a one-off data-loading task)
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

Assisted-by: Claude Code:claude-sonnet-5