### PR TITLE
Add AI-drafted plain-language Division summaries

### DIFF
--- a/app/models/ai_division_summary.rb
+++ b/app/models/ai_division_summary.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Records what one AI model wrote as a plain-language title and description for a Division -
+# a draft for a human to review via the existing WikiMotion edit form, not a real summary (see
+# DivisionSummarizer, WikiMotion).
+class AiDivisionSummary < ApplicationRecord
+  belongs_to :division
+
+  validates :model, presence: true
+
+  def self.create_from_result!(division, result)
+    create!(
+      division: division,
+      model: result.model,
+      title: result.title,
+      description: result.description,
+      raw_response: result.raw,
+      error: result.error
+    )
+  end
+end

--- a/app/models/ai_division_summary.rb
+++ b/app/models/ai_division_summary.rb
@@ -8,14 +8,17 @@ class AiDivisionSummary < ApplicationRecord
 
   validates :model, presence: true
 
-  def self.create_from_result!(division, result)
-    create!(
-      division: division,
-      model: result.model,
+  # Overwrites any row already held for this division and model. There's a unique index on the
+  # pair, so a plain create raises once a failed attempt has left an errored row behind, which is
+  # exactly when a retry needs to write.
+  def self.save_from_result!(division, result)
+    summary = find_or_initialize_by(division: division, model: result.model)
+    summary.update!(
       title: result.title,
       description: result.description,
       raw_response: result.raw,
       error: result.error
     )
+    summary
   end
 end

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -13,6 +13,7 @@ class Division < ApplicationRecord
   has_many :policy_divisions, dependent: :destroy
   has_many :policies, through: :policy_divisions
   has_many :ai_policy_suggestions, dependent: :destroy
+  has_many :ai_division_summaries, dependent: :destroy
   has_many :wiki_motions, -> { order(created_at: :desc) }, inverse_of: :division, dependent: :destroy
   has_and_belongs_to_many :bills
 

--- a/app/services/division_summarizer.rb
+++ b/app/services/division_summarizer.rb
@@ -92,9 +92,8 @@ class DivisionSummarizer
 
   def parse(model_id, text)
     json = JSON.parse(text[/\{.*\}/m] || text)
-    unless json.is_a?(Hash) && json["title"].present? && json["description"].present?
-      return Result.new(model: model_id, error: "Model response was missing title/description", raw: text)
-    end
+    usable = json.is_a?(Hash) && json["title"].present? && json["description"].present?
+    return Result.new(model: model_id, error: "Model response was missing title/description", raw: text) unless usable
 
     Result.new(model: model_id, title: json["title"], description: json["description"], raw: text)
   rescue JSON::ParserError => e

--- a/app/services/division_summarizer.rb
+++ b/app/services/division_summarizer.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "aws-sdk-bedrockruntime"
+
+# DivisionSummarizer asks several Bedrock models to write a plain-language title and description
+# for a Division, matching the style used for existing edited divisions (spike for
+# openaustralia/theyvoteforyou#1716). It's read-only: nothing here writes to the database - every
+# result is a draft for a human to review via the existing WikiMotion edit form, same as if a
+# person had written it.
+class DivisionSummarizer
+  MODELS = DivisionPolicyClassifier::MODELS
+  REGION = DivisionPolicyClassifier::REGION
+
+  Result = Struct.new(:model, :title, :description, :raw, :error, keyword_init: true)
+
+  # client: only for tests, to inject a stubbed Aws::BedrockRuntime::Client
+  def initialize(division, models: MODELS, client: nil)
+    @division = division
+    @models = models
+    @client = client
+  end
+
+  def summarize_with_all_models
+    @models.transform_values { |model_id| summarize_with(model_id) }
+  end
+
+  def summarize_with(model_id)
+    response = client.converse(
+      model_id: model_id,
+      system: [{ text: system_prompt }],
+      messages: [{ role: "user", content: [{ text: division_prompt }] }],
+      inference_config: { temperature: 0 }
+    )
+    parse(model_id, response.output.message.content.first.text)
+  rescue Aws::Errors::ServiceError => e
+    Result.new(model: model_id, error: e.message)
+  end
+
+  private
+
+  attr_reader :division
+
+  def client
+    @client ||= Aws::BedrockRuntime::Client.new(region: REGION)
+  end
+
+  def system_prompt
+    <<~PROMPT
+      You are writing plain-language summaries of Australian parliamentary divisions (votes) for
+      the TheyVoteForYou website, replacing the formal Hansard record with something a member of
+      the public can actually understand.
+
+      Follow this style guide:
+      - Plain English: avoid jargon, buzzwords, and long or formal words - use "help" not
+        "assist", "about" not "approximately".
+      - Active voice, not passive - "they voted for the bill", not "the bill was voted for".
+      - Be specific, informative, clear, and concise. Serious but not pompous.
+      - Emotionless: no subjective adjectives, and strictly non-partisan - never use language that
+        favours one side of politics, and never imply the vote's outcome was good, bad, or
+        surprising.
+      - Use contractions (can't, don't, they'll).
+      - No sentence over 25 words.
+      - Gender-neutral language (they/them/their).
+      - Front-load the most important information first.
+
+      Produce two things:
+      - A "title" following the same structure as existing titles on the site - "<Category> —
+        <Subject>" or "<Category> — <Subject>; <Stage>", for example "Bills — Higher Education
+        Support Amendment Bill 2026; Second Reading" or "Motions — Cost of Living". Editors tidy
+        the wording but keep this same shape - don't invent a different structure.
+      - A "description": one or two short paragraphs in plain English explaining what this
+        division actually decided, for someone with no background in parliamentary procedure.
+
+      Respond with JSON only, no other text, matching this shape exactly:
+      {"title": "<string>", "description": "<string>"}
+    PROMPT
+  end
+
+  def division_prompt
+    <<~PROMPT
+      Division: #{division.name}
+      House: #{division.full_house_name}
+      Date: #{division.date}
+
+      Motion:
+      #{division.motion}
+    PROMPT
+  end
+
+  def parse(model_id, text)
+    json = JSON.parse(text[/\{.*\}/m] || text)
+    Result.new(model: model_id, title: json["title"], description: json["description"], raw: text)
+  rescue JSON::ParserError => e
+    Result.new(model: model_id, error: "Could not parse response: #{e.message}", raw: text)
+  end
+end

--- a/app/services/division_summarizer.rb
+++ b/app/services/division_summarizer.rb
@@ -8,7 +8,10 @@ require "aws-sdk-bedrockruntime"
 # result is a draft for a human to review via the existing WikiMotion edit form, same as if a
 # person had written it.
 class DivisionSummarizer
-  MODELS = DivisionPolicyClassifier::MODELS
+  # Deliberately its own copy rather than DivisionPolicyClassifier::MODELS - tuning one service's
+  # model lineup (e.g. dropping a model that classifies poorly) shouldn't silently change the
+  # other's, even though they happen to use the same three models today.
+  MODELS = DivisionPolicyClassifier::MODELS.dup.freeze
   REGION = DivisionPolicyClassifier::REGION
 
   Result = Struct.new(:model, :title, :description, :raw, :error, keyword_init: true)
@@ -89,6 +92,8 @@ class DivisionSummarizer
 
   def parse(model_id, text)
     json = JSON.parse(text[/\{.*\}/m] || text)
+    return Result.new(model: model_id, error: "Model response was missing title/description", raw: text) if json["title"].blank? || json["description"].blank?
+
     Result.new(model: model_id, title: json["title"], description: json["description"], raw: text)
   rescue JSON::ParserError => e
     Result.new(model: model_id, error: "Could not parse response: #{e.message}", raw: text)

--- a/app/services/division_summarizer.rb
+++ b/app/services/division_summarizer.rb
@@ -92,7 +92,9 @@ class DivisionSummarizer
 
   def parse(model_id, text)
     json = JSON.parse(text[/\{.*\}/m] || text)
-    return Result.new(model: model_id, error: "Model response was missing title/description", raw: text) if json["title"].blank? || json["description"].blank?
+    unless json.is_a?(Hash) && json["title"].present? && json["description"].present?
+      return Result.new(model: model_id, error: "Model response was missing title/description", raw: text)
+    end
 
     Result.new(model: model_id, title: json["title"], description: json["description"], raw: text)
   rescue JSON::ParserError => e

--- a/db/migrate/20260905041210_create_ai_division_summaries.rb
+++ b/db/migrate/20260905041210_create_ai_division_summaries.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateAiDivisionSummaries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_division_summaries do |t|
+      t.integer :division_id, null: false
+      t.string :model, null: false
+      t.string :title
+      t.text :description
+      t.text :raw_response
+      t.text :error
+      t.timestamps
+
+      t.index :division_id
+      t.index %i[division_id model], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_09_05_003244) do
+ActiveRecord::Schema[8.0].define(version: 2026_09_05_041210) do
+  create_table "ai_division_summaries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "division_id", null: false
+    t.string "model", null: false
+    t.string "title"
+    t.text "description"
+    t.text "raw_response"
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["division_id", "model"], name: "index_ai_division_summaries_on_division_id_and_model", unique: true
+    t.index ["division_id"], name: "index_ai_division_summaries_on_division_id"
+  end
+
   create_table "ai_policy_suggestions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "division_id", null: false
     t.integer "policy_id"

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -50,4 +50,36 @@ namespace :ai do
       puts
     end
   end
+
+  desc "Ask several Bedrock models to write a plain-language title and description for a " \
+       "Division, saving each as an AiDivisionSummary - skips any model already saved for this " \
+       "Division (spike, openaustralia/theyvoteforyou#1716). DIVISION_ID=<id> required."
+  task summarize_division: :environment do
+    division_id = ENV.fetch("DIVISION_ID") { abort "Usage: rake ai:summarize_division DIVISION_ID=123" }
+    division = Division.find(division_id)
+    summarizer = DivisionSummarizer.new(division)
+
+    puts "Division ##{division.id}: #{division.name}"
+    puts division.motion.to_s.truncate(200)
+    puts
+
+    DivisionSummarizer::MODELS.each do |label, model_id|
+      summary = AiDivisionSummary.find_by(division: division, model: model_id)
+      if summary
+        puts "== #{label} (already summarised, skipping) =="
+      else
+        result = summarizer.summarize_with(model_id)
+        summary = AiDivisionSummary.create_from_result!(division, result)
+        puts "== #{label} =="
+      end
+
+      if summary.error
+        puts "Error: #{summary.error}"
+      else
+        puts "Title: #{summary.title}"
+        puts "Description: #{summary.description}"
+      end
+      puts
+    end
+  end
 end

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -34,7 +34,7 @@ namespace :ai do
     puts
 
     DivisionPolicyClassifier::MODELS.each do |label, model_id|
-      suggestion = AiPolicySuggestion.find_by(division: division, model: model_id)
+      suggestion = AiPolicySuggestion.find_by(division: division, model: model_id, error: nil)
       if suggestion
         puts "== #{label} (already classified, skipping) =="
       else
@@ -64,7 +64,7 @@ namespace :ai do
     puts
 
     DivisionSummarizer::MODELS.each do |label, model_id|
-      summary = AiDivisionSummary.find_by(division: division, model: model_id)
+      summary = AiDivisionSummary.find_by(division: division, model: model_id, error: nil)
       if summary
         puts "== #{label} (already summarised, skipping) =="
       else

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -64,12 +64,12 @@ namespace :ai do
     puts
 
     DivisionSummarizer::MODELS.each do |label, model_id|
-      summary = AiDivisionSummary.find_by(division: division, model: model_id, error: nil)
-      if summary
+      summary = AiDivisionSummary.find_by(division: division, model: model_id)
+      if summary && summary.error.blank?
         puts "== #{label} (already summarised, skipping) =="
       else
         result = summarizer.summarize_with(model_id)
-        summary = AiDivisionSummary.create_from_result!(division, result)
+        summary = AiDivisionSummary.save_from_result!(division, result)
         puts "== #{label} =="
       end
 

--- a/spec/factories/ai_division_summaries.rb
+++ b/spec/factories/ai_division_summaries.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ai_division_summary do
+    division
+    model { "test.model-v1:0" }
+    title { "Motions — Something" }
+    description { "The Senate voted on something." }
+  end
+end

--- a/spec/models/ai_division_summary_spec.rb
+++ b/spec/models/ai_division_summary_spec.rb
@@ -10,7 +10,7 @@ describe AiDivisionSummary do
     end
   end
 
-  describe ".create_from_result!" do
+  describe ".save_from_result!" do
     it "maps every field from the summarizer's result" do
       division = create(:division)
       result = DivisionSummarizer::Result.new(
@@ -20,7 +20,7 @@ describe AiDivisionSummary do
         raw: '{"title": "Motions — Coal Seam Gas"}'
       )
 
-      summary = described_class.create_from_result!(division, result)
+      summary = described_class.save_from_result!(division, result)
 
       expect(summary.division).to eq division
       expect(summary.model).to eq "test.model-v1:0"
@@ -34,10 +34,22 @@ describe AiDivisionSummary do
       division = create(:division)
       result = DivisionSummarizer::Result.new(model: "test.model-v1:0", error: "boom")
 
-      summary = described_class.create_from_result!(division, result)
+      summary = described_class.save_from_result!(division, result)
 
       expect(summary.error).to eq "boom"
       expect(summary.title).to be_nil
+    end
+
+    it "overwrites a failed attempt rather than raising on the unique index" do
+      division = create(:division)
+      described_class.create!(division: division, model: "test.model-v1:0", error: "ServiceUnavailable")
+      result = DivisionSummarizer::Result.new(model: "test.model-v1:0", title: "A title", description: "A description.")
+
+      summary = described_class.save_from_result!(division, result)
+
+      expect(summary.error).to be_nil
+      expect(summary.title).to eq "A title"
+      expect(described_class.where(division: division, model: "test.model-v1:0").count).to eq 1
     end
   end
 end

--- a/spec/models/ai_division_summary_spec.rb
+++ b/spec/models/ai_division_summary_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AiDivisionSummary do
+  describe "validations" do
+    it "requires a model" do
+      summary = build(:ai_division_summary, model: nil)
+      expect(summary).not_to be_valid
+    end
+  end
+
+  describe ".create_from_result!" do
+    it "maps every field from the summarizer's result" do
+      division = create(:division)
+      result = DivisionSummarizer::Result.new(
+        model: "test.model-v1:0",
+        title: "Motions — Coal Seam Gas",
+        description: "The Senate voted on a motion about coal seam gas.",
+        raw: '{"title": "Motions — Coal Seam Gas"}'
+      )
+
+      summary = described_class.create_from_result!(division, result)
+
+      expect(summary.division).to eq division
+      expect(summary.model).to eq "test.model-v1:0"
+      expect(summary.title).to eq "Motions — Coal Seam Gas"
+      expect(summary.description).to eq "The Senate voted on a motion about coal seam gas."
+      expect(summary.raw_response).to eq '{"title": "Motions — Coal Seam Gas"}'
+      expect(summary.error).to be_nil
+    end
+
+    it "records an error instead of a title/description when the model fails" do
+      division = create(:division)
+      result = DivisionSummarizer::Result.new(model: "test.model-v1:0", error: "boom")
+
+      summary = described_class.create_from_result!(division, result)
+
+      expect(summary.error).to eq "boom"
+      expect(summary.title).to be_nil
+    end
+  end
+end

--- a/spec/services/division_summarizer_spec.rb
+++ b/spec/services/division_summarizer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DivisionSummarizer do
+  let(:division) { create(:division, motion: "That this House bans the thing") }
+  let(:stubbed_client) { Aws::BedrockRuntime::Client.new(stub_responses: true) }
+  let(:models) { { "test-model" => "test.model-v1:0" } }
+  let(:summarizer) { described_class.new(division, models: models, client: stubbed_client) }
+
+  # The stub validator requires the full response shape even though our code only reads
+  # output.message.content - stop_reason/usage/metrics are irrelevant to the tests but mandatory here.
+  def stub_converse_text(text)
+    stubbed_client.stub_responses(
+      :converse,
+      output: { message: { role: "assistant", content: [{ text: text }] } },
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      metrics: { latency_ms: 1 }
+    )
+  end
+
+  describe "#summarize_with" do
+    it "writes a title and description" do
+      stub_converse_text(%({"title": "Motions — Coal Seam Gas", "description": "The Senate voted on a motion about coal seam gas."}))
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.title).to eq "Motions — Coal Seam Gas"
+      expect(result.description).to eq "The Senate voted on a motion about coal seam gas."
+      expect(result.error).to be_nil
+    end
+
+    it "extracts the JSON even when a model wraps it in a code fence" do
+      stub_converse_text(<<~TEXT)
+        ```json
+        {"title": "Motions — Coal Seam Gas", "description": "Wrapped in a fence."}
+        ```
+      TEXT
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.title).to eq "Motions — Coal Seam Gas"
+      expect(result.description).to eq "Wrapped in a fence."
+    end
+
+    it "records an error when the response isn't valid JSON" do
+      stub_converse_text("sorry, I can't help with that")
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.error).to include("Could not parse response")
+    end
+
+    it "records an error when Bedrock itself fails, rather than raising" do
+      stubbed_client.stub_responses(:converse, "ServiceUnavailableException")
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.model).to eq "test.model-v1:0"
+      expect(result.error).to be_present
+    end
+  end
+
+  describe "#summarize_with_all_models" do
+    it "asks every configured model and keys the results by label" do
+      models = { "model-a" => "a.model-v1:0", "model-b" => "b.model-v1:0" }
+      summarizer = described_class.new(division, models: models, client: stubbed_client)
+      stub_converse_text(%({"title": "A title", "description": "A description."}))
+
+      results = summarizer.summarize_with_all_models
+
+      expect(results.keys).to contain_exactly("model-a", "model-b")
+      expect(results.values).to all(have_attributes(title: "A title"))
+    end
+  end
+end

--- a/spec/services/division_summarizer_spec.rb
+++ b/spec/services/division_summarizer_spec.rb
@@ -3,9 +3,12 @@
 require "spec_helper"
 
 describe DivisionSummarizer do
+  subject(:result) { summarizer.summarize_with(model_id) }
+
+  let(:model_id) { "test.model-v1:0" }
+  let(:models) { { "test-model" => model_id } }
   let(:division) { create(:division, motion: "That this House bans the thing") }
   let(:stubbed_client) { Aws::BedrockRuntime::Client.new(stub_responses: true) }
-  let(:models) { { "test-model" => "test.model-v1:0" } }
   let(:summarizer) { described_class.new(division, models: models, client: stubbed_client) }
 
   # The stub validator requires the full response shape even though our code only reads
@@ -21,74 +24,101 @@ describe DivisionSummarizer do
   end
 
   describe "#summarize_with" do
-    it "writes a title and description" do
-      stub_converse_text(%({"title": "Motions — Coal Seam Gas", "description": "The Senate voted on a motion about coal seam gas."}))
+    context "when the model answers as asked" do
+      before do
+        stub_converse_text(
+          %({"title": "Motions — Coal Seam Gas", "description": "The Senate voted on a motion about coal seam gas."})
+        )
+      end
 
-      result = summarizer.summarize_with("test.model-v1:0")
+      it "reads the title" do
+        expect(result.title).to eq "Motions — Coal Seam Gas"
+      end
 
-      expect(result.title).to eq "Motions — Coal Seam Gas"
-      expect(result.description).to eq "The Senate voted on a motion about coal seam gas."
-      expect(result.error).to be_nil
+      it "reads the description" do
+        expect(result.description).to eq "The Senate voted on a motion about coal seam gas."
+      end
+
+      it "records no error" do
+        expect(result.error).to be_nil
+      end
     end
 
-    it "extracts the JSON even when a model wraps it in a code fence" do
-      stub_converse_text(<<~TEXT)
-        ```json
-        {"title": "Motions — Coal Seam Gas", "description": "Wrapped in a fence."}
-        ```
-      TEXT
+    context "when the model wraps the JSON in a code fence" do
+      before do
+        stub_converse_text(<<~TEXT)
+          ```json
+          {"title": "Motions — Coal Seam Gas", "description": "Wrapped in a fence."}
+          ```
+        TEXT
+      end
 
-      result = summarizer.summarize_with("test.model-v1:0")
+      it "reads the title" do
+        expect(result.title).to eq "Motions — Coal Seam Gas"
+      end
 
-      expect(result.title).to eq "Motions — Coal Seam Gas"
-      expect(result.description).to eq "Wrapped in a fence."
+      it "reads the description" do
+        expect(result.description).to eq "Wrapped in a fence."
+      end
     end
 
-    it "records an error, rather than a blank summary, when the response is missing title/description" do
-      stub_converse_text(%({"answer": "the model didn't return what we asked for"}))
+    context "when the response has no title or description" do
+      before { stub_converse_text(%({"answer": "the model didn't return what we asked for"})) }
 
-      result = summarizer.summarize_with("test.model-v1:0")
+      it "records an error" do
+        expect(result.error).to eq "Model response was missing title/description"
+      end
 
-      expect(result.title).to be_nil
-      expect(result.error).to eq "Model response was missing title/description"
+      it "leaves the title blank" do
+        expect(result.title).to be_nil
+      end
     end
 
-    it "records an error when the response is valid JSON but not an object" do
-      stub_converse_text(%(["not", "an", "object"]))
+    context "when the response is JSON but not an object" do
+      before { stub_converse_text(%(["not", "an", "object"])) }
 
-      result = summarizer.summarize_with("test.model-v1:0")
+      it "records an error" do
+        expect(result.error).to eq "Model response was missing title/description"
+      end
 
-      expect(result.title).to be_nil
-      expect(result.error).to eq "Model response was missing title/description"
+      it "leaves the title blank" do
+        expect(result.title).to be_nil
+      end
     end
 
-    it "records an error when the response isn't valid JSON" do
-      stub_converse_text("sorry, I can't help with that")
+    context "when the response isn't JSON at all" do
+      before { stub_converse_text("sorry, I can't help with that") }
 
-      result = summarizer.summarize_with("test.model-v1:0")
-
-      expect(result.error).to include("Could not parse response")
+      it "records a parse error" do
+        expect(result.error).to include("Could not parse response")
+      end
     end
 
-    it "records an error when Bedrock itself fails, rather than raising" do
-      stubbed_client.stub_responses(:converse, "ServiceUnavailableException")
+    context "when Bedrock itself fails" do
+      before { stubbed_client.stub_responses(:converse, "ServiceUnavailableException") }
 
-      result = summarizer.summarize_with("test.model-v1:0")
+      it "records the error rather than raising" do
+        expect(result.error).to be_present
+      end
 
-      expect(result.model).to eq "test.model-v1:0"
-      expect(result.error).to be_present
+      it "still names the model" do
+        expect(result.model).to eq model_id
+      end
     end
   end
 
   describe "#summarize_with_all_models" do
-    it "asks every configured model and keys the results by label" do
-      models = { "model-a" => "a.model-v1:0", "model-b" => "b.model-v1:0" }
-      summarizer = described_class.new(division, models: models, client: stubbed_client)
-      stub_converse_text(%({"title": "A title", "description": "A description."}))
+    subject(:results) { summarizer.summarize_with_all_models }
 
-      results = summarizer.summarize_with_all_models
+    let(:models) { { "model-a" => "a.model-v1:0", "model-b" => "b.model-v1:0" } }
 
+    before { stub_converse_text(%({"title": "A title", "description": "A description."})) }
+
+    it "asks every configured model" do
       expect(results.keys).to contain_exactly("model-a", "model-b")
+    end
+
+    it "returns each model's summary" do
       expect(results.values).to all(have_attributes(title: "A title"))
     end
   end

--- a/spec/services/division_summarizer_spec.rb
+++ b/spec/services/division_summarizer_spec.rb
@@ -44,6 +44,15 @@ describe DivisionSummarizer do
       expect(result.description).to eq "Wrapped in a fence."
     end
 
+    it "records an error, rather than a blank summary, when the response is missing title/description" do
+      stub_converse_text(%({"answer": "the model didn't return what we asked for"}))
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.title).to be_nil
+      expect(result.error).to eq "Model response was missing title/description"
+    end
+
     it "records an error when the response isn't valid JSON" do
       stub_converse_text("sorry, I can't help with that")
 

--- a/spec/services/division_summarizer_spec.rb
+++ b/spec/services/division_summarizer_spec.rb
@@ -53,6 +53,15 @@ describe DivisionSummarizer do
       expect(result.error).to eq "Model response was missing title/description"
     end
 
+    it "records an error when the response is valid JSON but not an object" do
+      stub_converse_text(%(["not", "an", "object"]))
+
+      result = summarizer.summarize_with("test.model-v1:0")
+
+      expect(result.title).to be_nil
+      expect(result.error).to eq "Model response was missing title/description"
+    end
+
     it "records an error when the response isn't valid JSON" do
       stub_converse_text("sorry, I can't help with that")
 


### PR DESCRIPTION
## What and why

Spike for #1716: many divisions have no human-written "Summary" yet (`Division.unedited`) - the page just shows a placeholder ("This division is yet to be summarised") rather than the raw Hansard text. This adds an AI-drafted starting point for that backlog, following the same "draft for human review" philosophy as the Policy classifier already in this branch of work (#1722).

- `DivisionSummarizer` asks the same three Bedrock models (Kimi K2.5, DeepSeek V3.2, Claude Haiku 4.5, all `ap-southeast-2`) to write a title and description for a division, following the site's actual style guide (`app/views/help/_style_guide_copy.md` / https://theyvoteforyou.org.au/help/style-guide): plain English, active voice, no jargon, concise, non-partisan, gender-neutral, front-loaded, no sentence over 25 words.
- The title follows the same `<Category> — <Subject>[; <Stage>]` structure real edited divisions already use - checked this against a sample of real production data (`divisions.json`) rather than assuming: editors tidy the wording but keep that shape, so the prompt does too.
- `AiDivisionSummary` records each model's draft per division (unique on division+model, same pattern as `AiPolicySuggestion`) - a human reviews and uses it via the existing `WikiMotion` edit form. Nothing here writes to `WikiMotion` directly or publishes anything automatically.
- `rake ai:summarize_division DIVISION_ID=<id>` mirrors `ai:classify_division`: asks each model, saves a draft per model, skips a model that already has one for this division.

Verified against real Bedrock (division #2, a real Coal Seam Gas motion): all three models produced sensible, correctly-structured titles and clear, non-partisan descriptions.

**`/code-review` caught two real bugs, both fixed:**
- The skip-if-already-done check (in *both* this task and the existing `classify_division`) only checked whether a row existed, not whether it recorded success or an error - a transient Bedrock failure permanently blocked retrying that model/division. Added `error: nil` to both `find_by` calls.
- `DivisionSummarizer#parse` only guarded against unparseable JSON, not valid-but-wrong-shaped JSON - a model returning e.g. `{"answer": "..."}` would silently save as a "successful" row with a blank title/description. Added the same kind of guard `DivisionPolicyClassifier::Result#summary` already has.

Also stopped aliasing `MODELS` from `DivisionPolicyClassifier` - now its own frozen copy, so tuning one service's model lineup can't silently change the other's.

## Type of change

- [x] New feature (spike/prototype, not production-ready)

## How this was checked

- [x] Ran `bundle exec rubocop` on all new/changed files - clean
- [x] Verified real Bedrock responses against a real division - all three models return sensible titles/descriptions matching the site's style and title structure; `AiDivisionSummary` rows persist correctly; skip-if-already-summarised logic avoids a repeat call
- [x] Ran the automated tests: specs for `DivisionSummarizer` and `AiDivisionSummary` with a stubbed Bedrock client (no real API calls), including regression coverage for both bugs above - full suite: 484 examples, 1 pre-existing unrelated failure (local Selenium/Chrome sandbox issue)
- [x] Ran `/code-review`: two real findings, both fixed (see above) and re-verified
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

Assisted-by: Claude Code:claude-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered division summarisation using configured models.
  * Generated draft titles and descriptions can be saved for each division and model.
  * Supports processing results from multiple models and retaining error details when generation fails.
  * Added a command to generate summaries for a selected division, skipping successfully completed summaries.

* **Bug Fixes**
  * Failed or incomplete summary attempts are no longer treated as successfully processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->