### PR TITLE
Add a staff-only AI policy suggestions panel to divisions#show

### DIFF
--- a/app/assets/stylesheets/divisions/_division-show.scss
+++ b/app/assets/stylesheets/divisions/_division-show.scss
@@ -33,6 +33,11 @@
     border-left-color: $color-vote-against;
   }
 
+  // Dashed rather than solid: this model hasn't run, as opposed to having run and landed somewhere.
+  .ai-policy-suggestion-unclassified {
+    border-left-style: dashed;
+  }
+
   .ai-policy-suggestion-reasoning {
     font-style: italic;
   }

--- a/app/assets/stylesheets/divisions/_division-show.scss
+++ b/app/assets/stylesheets/divisions/_division-show.scss
@@ -3,6 +3,22 @@
 }
 
 #ai-policy-suggestions {
+  .ai-policy-suggestion {
+    margin-bottom: 1.5em;
+
+    h3 {
+      margin-bottom: 0.25em;
+    }
+
+    p {
+      margin-bottom: 0.25em;
+    }
+  }
+
+  .ai-policy-suggestion-reasoning {
+    font-style: italic;
+  }
+
   a[data-toggle="collapse"] {
     .when-expanded {
       display: none;

--- a/app/assets/stylesheets/divisions/_division-show.scss
+++ b/app/assets/stylesheets/divisions/_division-show.scss
@@ -3,8 +3,12 @@
 }
 
 #ai-policy-suggestions {
+  // Each model's block is bordered by what it came back with, so matches against an existing
+  // policy and proposals for a new one are tellable apart without reading each one.
   .ai-policy-suggestion {
     margin-bottom: 1.5em;
+    padding: 0.5em 0.75em;
+    border-left: 4px solid $color-mixed-position;
 
     h3 {
       margin-bottom: 0.25em;
@@ -13,6 +17,20 @@
     p {
       margin-bottom: 0.25em;
     }
+  }
+
+  .ai-policy-suggestion-existing {
+    border-left-color: $color-blue;
+    background-color: mix($color-blue, #fff, 5%);
+  }
+
+  .ai-policy-suggestion-new {
+    border-left-color: $color-orange;
+    background-color: mix($color-orange, #fff, 12%);
+  }
+
+  .ai-policy-suggestion-error {
+    border-left-color: $color-vote-against;
   }
 
   .ai-policy-suggestion-reasoning {

--- a/app/assets/stylesheets/divisions/_division-show.scss
+++ b/app/assets/stylesheets/divisions/_division-show.scss
@@ -2,6 +2,24 @@
   padding: 0;
 }
 
+#ai-policy-suggestions {
+  a[data-toggle="collapse"] {
+    .when-expanded {
+      display: none;
+    }
+
+    &[aria-expanded="true"] {
+      .when-collapsed {
+        display: none;
+      }
+
+      .when-expanded {
+        display: inline;
+      }
+    }
+  }
+}
+
 .division-external-links {
   width: 100%;
   clear: left;

--- a/app/lib/division_ai_suggestions.rb
+++ b/app/lib/division_ai_suggestions.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Assembles what the division page's staff-only AI suggestions panel needs: one Row per model the
+# classifier knows how to label, and whether the models unanimously landed on a policy the division
+# isn't linked to yet. It decides nothing about classification itself - that's
+# DivisionPolicyClassifier writing AiPolicySuggestion records - it only works out how those records
+# sit against each other and against the connections a human has already made.
+class DivisionAiSuggestions
+  # The models agreed on this policy and direction, and nothing links the division to it yet.
+  Unanimous = Struct.new(:policy, :direction, keyword_init: true) do
+    # PolicyDivision stores a vote, not a direction: a supporter of a "for" policy votes aye.
+    def vote
+      direction == "for" ? "aye" : "no"
+    end
+  end
+
+  delegate :any?, to: :suggestions
+
+  def initialize(division)
+    @division = division
+  end
+
+  def model_count
+    known_models.size
+  end
+
+  def each(&)
+    known_models.map { |model_id, label| Row.new(self, label, suggestions[model_id]) }.each(&)
+  end
+
+  # nil unless every model matched the same existing policy in the same direction, and that policy
+  # isn't already linked - the one case the panel offers to act on in a single click.
+  def unanimous
+    return @unanimous if defined?(@unanimous)
+
+    @unanimous = build_unanimous
+  end
+
+  def agree_count(suggestion)
+    agreement[[suggestion.policy_id, suggestion.direction]].to_i
+  end
+
+  def linked_vote(suggestion)
+    linked_votes[suggestion.policy_id]
+  end
+
+  private
+
+  attr_reader :division
+
+  def known_models
+    DivisionPolicyClassifier::MODEL_LABELS
+  end
+
+  # Only models the panel can label: a suggestion left over from a model id since retired from
+  # MODEL_LABELS shouldn't count towards agreement nobody can see it taking part in.
+  def suggestions
+    @suggestions ||= division.ai_policy_suggestions
+                             .includes(:policy)
+                             .index_by(&:model)
+                             .slice(*known_models.keys)
+  end
+
+  # policy_id is nil both for new-policy proposals and for matches whose policy can no longer be
+  # found, so it can't stand in for "these two agree" - only real classifications naming a policy
+  # are counted.
+  def agreement
+    @agreement ||= suggestions.values
+                              .reject(&:error?)
+                              .select { |s| s.match == "existing" && s.policy_id }
+                              .group_by { |s| [s.policy_id, s.direction] }
+                              .transform_values(&:size)
+  end
+
+  def linked_votes
+    @linked_votes ||= division.policy_divisions.pluck(:policy_id, :vote).to_h
+  end
+
+  def build_unanimous
+    policy_id, direction = agreement.key(model_count)
+    return if policy_id.nil? || linked_votes.key?(policy_id)
+
+    policy = suggestions.values.find { |s| s.policy_id == policy_id }&.policy
+    Unanimous.new(policy: policy, direction: direction) if policy
+  end
+
+  # One model's row: its label, what it came back with (if anything), and how that sits against the
+  # other models and against what's already linked.
+  class Row
+    attr_reader :label, :suggestion
+
+    delegate :summary, :direction, :policy, :reasoning, :error?,
+             :proposed_policy_name, :proposed_policy_description, to: :suggestion
+
+    def initialize(panel, label, suggestion)
+      @panel = panel
+      @label = label
+      @suggestion = suggestion
+    end
+
+    def unclassified?
+      suggestion.nil?
+    end
+
+    def new_policy?
+      suggestion.match == "new"
+    end
+
+    def css_class
+      "ai-policy-suggestion-#{unclassified? ? 'unclassified' : suggestion.outcome}"
+    end
+
+    def vote_class
+      direction == "for" ? "voted-aye" : "voted-no"
+    end
+
+    def agree_count
+      panel.agree_count(suggestion)
+    end
+
+    def agreement?
+      agree_count > 1
+    end
+
+    def linked_same_way?
+      linked_vote.present? && PolicyDivision.vote_without_strong(linked_vote) == suggested_vote
+    end
+
+    def linked_other_way?
+      linked_vote.present? && !linked_same_way?
+    end
+
+    private
+
+    attr_reader :panel
+
+    def linked_vote
+      panel.linked_vote(suggestion)
+    end
+
+    def suggested_vote
+      direction == "for" ? "aye" : "no"
+    end
+  end
+end

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -4,6 +4,13 @@
 # either an existing Policy match or a proposed new one - along with its reasoning. A draft for a
 # human to review, not a real classification (see DivisionPolicyClassifier, PolicyDivision).
 class AiPolicySuggestion < ApplicationRecord
+  # Two different things leave an "existing" match with no policy, and they're indistinguishable
+  # afterwards: the Policy was deleted (which nullifies policy_id too, via Policy has_many
+  # :ai_policy_suggestions, dependent: :nullify), or the model named an id that never resolved
+  # (DivisionPolicyClassifier#parse stores nil rather than the id it was given). So this says what
+  # can be observed rather than guessing which happened. The division page shows it too.
+  POLICY_NOT_FOUND = "a policy that can no longer be found"
+
   belongs_to :division
   belongs_to :policy, optional: true
 
@@ -49,10 +56,8 @@ class AiPolicySuggestion < ApplicationRecord
 
   private
 
-  # Deleting a Policy nullifies policy_id on its suggestions (Policy has_many :ai_policy_suggestions,
-  # dependent: :nullify), so once it's gone there's no id left to name either.
   def existing_policy_subject
-    return "a policy that has since been deleted" unless policy
+    return POLICY_NOT_FOUND unless policy
 
     "policy #{policy_id} (#{policy.name})"
   end

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -43,8 +43,11 @@ class AiPolicySuggestion < ApplicationRecord
 
   private
 
-  # policy can be nil if the matched Policy has since been deleted
+  # Deleting a Policy nullifies policy_id on its suggestions (Policy has_many :ai_policy_suggestions,
+  # dependent: :nullify), so once it's gone there's no id left to name either.
   def existing_policy_subject
-    policy ? "policy #{policy_id} (#{policy.name})" : "policy #{policy_id}"
+    return "a policy that has since been deleted" unless policy
+
+    "policy #{policy_id} (#{policy.name})"
   end
 end

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -34,7 +34,7 @@ class AiPolicySuggestion < ApplicationRecord
   end
 
   def summary
-    return "Error: #{error}" if error
+    return "Error: #{error}" if error.present?
     return "Error: model response was missing match/direction" if match.nil? || direction.nil?
 
     subject = match == "existing" ? existing_policy_subject : "new policy I propose"

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -33,6 +33,12 @@ class AiPolicySuggestion < ApplicationRecord
     error.present? || match.nil? || direction.nil?
   end
 
+  # How this suggestion turned out: an error, a match against an existing Policy, or a proposal
+  # for a new one. Never nil - a missing match is itself an error (see #error?).
+  def outcome
+    error? ? "error" : match
+  end
+
   def summary
     return "Error: #{error}" if error.present?
     return "Error: model response was missing match/direction" if match.nil? || direction.nil?

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -26,6 +26,13 @@ class AiPolicySuggestion < ApplicationRecord
     )
   end
 
+  # True whenever #summary describes an error rather than an actual classification, whether or
+  # not the error column itself is set (a nil match/direction is a malformed response, not
+  # something DivisionPolicyClassifier flagged as an error at the time).
+  def error?
+    error.present? || match.nil? || direction.nil?
+  end
+
   def summary
     return "Error: #{error}" if error
     return "Error: model response was missing match/direction" if match.nil? || direction.nil?

--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -30,7 +30,14 @@ class AiPolicySuggestion < ApplicationRecord
     return "Error: #{error}" if error
     return "Error: model response was missing match/direction" if match.nil? || direction.nil?
 
-    subject = match == "existing" ? "policy #{policy_id}" : "new policy I propose"
+    subject = match == "existing" ? existing_policy_subject : "new policy I propose"
     "#{direction == 'for' ? 'For' : 'Against'} #{subject}"
+  end
+
+  private
+
+  # policy can be nil if the matched Policy has since been deleted
+  def existing_policy_subject
+    policy ? "policy #{policy_id} (#{policy.name})" : "policy #{policy_id}"
   end
 end

--- a/app/services/division_policy_classifier.rb
+++ b/app/services/division_policy_classifier.rb
@@ -20,6 +20,14 @@ class DivisionPolicyClassifier
     "claude-haiku-4.5" => "au.anthropic.claude-haiku-4-5-20251001-v1:0"
   }.freeze
 
+  # Human-readable names for display, keyed by model id (what AiPolicySuggestion#model stores)
+  # rather than by the MODELS slug.
+  MODEL_LABELS = {
+    "moonshotai.kimi-k2.5" => "Kimi K2.5",
+    "deepseek.v3.2" => "DeepSeek V3.2",
+    "au.anthropic.claude-haiku-4-5-20251001-v1:0" => "Claude Haiku 4.5"
+  }.freeze
+
   REGION = "ap-southeast-2"
 
   EXAMPLES_PER_POLICY = 2

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -2,9 +2,11 @@
 - if policy(division).edit? && suggestions.any?
   - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
   %section.page-section#ai-policy-suggestions
-    %h2
+    %h4
+      We have AI suggestions (staff only) -
       %a.collapsed{href: "#ai-policy-suggestions-body", role: "button", data: {toggle: "collapse"}, "aria-expanded" => "false", "aria-controls" => "ai-policy-suggestions-body"}
-        AI policy classification proposals (staff only)
+        %span.when-collapsed ▼ review
+        %span.when-expanded ▲ hide
     #ai-policy-suggestions-body.collapse
       %p.text-muted
         Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,0 +1,29 @@
+- suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model)
+- if policy(division).edit? && suggestions.any?
+  - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
+  %section.page-section#ai-policy-suggestions
+    %h2
+      %a.collapsed{href: "#ai-policy-suggestions-body", role: "button", data: {toggle: "collapse"}, "aria-expanded" => "false", "aria-controls" => "ai-policy-suggestions-body"}
+        AI policy classification proposals (staff only)
+    #ai-policy-suggestions-body.collapse
+      %p.text-muted
+        Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
+      - DivisionPolicyClassifier::MODEL_LABELS.each do |model_id, label|
+        .ai-policy-suggestion
+          %h3= label
+          - suggestion = suggestions[model_id]
+          - if suggestion.nil?
+            %p.text-muted Not yet classified.
+          - elsif suggestion.error
+            %p.text-danger= "Error: #{suggestion.error}"
+          - else
+            %p
+              = suggestion.summary
+              - if suggestion.match == "existing" && agreement[[suggestion.policy_id, suggestion.direction]].to_i > 1
+                %span.label.label-info= "#{agreement[[suggestion.policy_id, suggestion.direction]]} models agree"
+            - if suggestion.match == "new"
+              %p
+                %strong= suggestion.proposed_policy_name
+                = suggestion.proposed_policy_description
+            - if suggestion.reasoning.present?
+              %p.text-muted= suggestion.reasoning

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -19,7 +19,7 @@
         Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
       - DivisionPolicyClassifier::MODEL_LABELS.each do |model_id, label|
         .ai-policy-suggestion
-          %h3= label
+          %h3.h3= label
           - suggestion = suggestions[model_id]
           - if suggestion.nil?
             %p.text-muted Not yet classified.
@@ -28,7 +28,6 @@
           - else
             %p
               - if suggestion.match == "new"
-                new policy:
                 = suggestion.summary
               - elsif suggestion.policy
                 = link_to suggestion.summary, suggestion.policy
@@ -40,11 +39,13 @@
               - if suggestion.match == "existing" && linked_policy_ids.include?(suggestion.policy_id)
                 %span.label.label-success Already linked
             - if suggestion.match == "new"
-              %p
+              %p.ai-policy-suggestion-proposal
                 %strong= suggestion.proposed_policy_name
-                = suggestion.proposed_policy_description
+                - if suggestion.proposed_policy_description.present?
+                  %br
+                  = suggestion.proposed_policy_description
             - if suggestion.reasoning.present?
-              %p.text-muted= suggestion.reasoning
+              %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
       - if unanimous_policy && policy(PolicyDivision).new? && !linked_policy_ids.include?(unanimous_policy.id)
         .ai-policy-suggestions-unanimous.alert.alert-info
           %p

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -5,7 +5,7 @@
   - unanimous_policy_id, unanimous_direction = agreement.find { |_, count| count == DivisionPolicyClassifier::MODEL_LABELS.size }&.first
   - unanimous_policy = Policy.find_by(id: unanimous_policy_id) if unanimous_policy_id
   %section.page-section#ai-policy-suggestions
-    %h4
+    %h2.h5
       We have AI suggestions (staff only) -
       %a.collapsed{href: "#ai-policy-suggestions-body", role: "button", data: {toggle: "collapse"}, "aria-expanded" => "false", "aria-controls" => "ai-policy-suggestions-body"}
         %span.when-collapsed ▼ review

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -17,8 +17,8 @@
           - suggestion = suggestions[model_id]
           - if suggestion.nil?
             %p.text-muted Not yet classified.
-          - elsif suggestion.error
-            %p.text-danger= "Error: #{suggestion.error}"
+          - elsif suggestion.error?
+            %p.text-danger= suggestion.summary
           - else
             %p
               - if suggestion.match == "existing" && suggestion.policy

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -18,9 +18,9 @@
       %p.text-muted
         Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
       - DivisionPolicyClassifier::MODEL_LABELS.each do |model_id, label|
-        .ai-policy-suggestion
+        - suggestion = suggestions[model_id]
+        .ai-policy-suggestion{class: "ai-policy-suggestion-#{suggestion ? suggestion.outcome : 'unclassified'}"}
           %h3.h3= label
-          - suggestion = suggestions[model_id]
           - if suggestion.nil?
             %p.text-muted Not yet classified.
           - elsif suggestion.error?

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,6 +1,9 @@
 - suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model)
 - if policy(division).edit? && suggestions.any?
-  - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
+  -# policy_id is nil both for new-policy proposals and for matches whose policy was later deleted, so
+  -# it can't stand in for "these two agree" - only suggestions naming a real policy are counted.
+  - matched = suggestions.values.select { |s| s.match == "existing" && s.policy_id && s.direction }
+  - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
   - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
   - model_count = DivisionPolicyClassifier::MODEL_LABELS.size
   - unanimous_policy_id, unanimous_direction = agreement.key(model_count)

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -26,24 +26,25 @@
           - elsif suggestion.error?
             %p.text-danger= suggestion.summary
           - else
+            - vote_class = suggestion.direction == "for" ? "voted-aye" : "voted-no"
             %p
+              This vote is
+              %span.division-policy-statement-vote{class: vote_class}= suggestion.direction
               - if suggestion.match == "new"
-                = suggestion.summary
+                a new policy:
+                %strong= suggestion.proposed_policy_name
               - elsif suggestion.policy
-                = link_to suggestion.summary, suggestion.policy
+                an existing policy:
+                = link_to suggestion.policy.name, suggestion.policy
               - else
-                = suggestion.summary
+                a policy that has since been deleted
 
               - if suggestion.match == "existing" && agreement[[suggestion.policy_id, suggestion.direction]].to_i > 1
                 %span.label.label-info= "#{agreement[[suggestion.policy_id, suggestion.direction]]} models agree"
               - if suggestion.match == "existing" && linked_policy_ids.include?(suggestion.policy_id)
                 %span.label.label-success Already linked
-            - if suggestion.match == "new"
-              %p.ai-policy-suggestion-proposal
-                %strong= suggestion.proposed_policy_name
-                - if suggestion.proposed_policy_description.present?
-                  %br
-                  = suggestion.proposed_policy_description
+            - if suggestion.match == "new" && suggestion.proposed_policy_description.present?
+              %p.ai-policy-suggestion-proposal= suggestion.proposed_policy_description
             - if suggestion.reasoning.present?
               %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
       - if unanimous_policy && policy(PolicyDivision).new? && !linked_policy_ids.include?(unanimous_policy.id)

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,20 +1,8 @@
 -# Gated on the policy governing the connections this panel offers to make, not on editing the
 -# division, so widening who may edit a division can't publish unreviewed AI drafts.
 - if policy(PolicyDivision).new?
-  -# Only models the panel can label: a suggestion left over from a model id since retired from
-  -# MODEL_LABELS shouldn't count towards agreement nobody can see it taking part in.
-  - known_models = DivisionPolicyClassifier::MODEL_LABELS
-  - suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model).slice(*known_models.keys)
-  - if suggestions.any?
-    -# policy_id is nil both for new-policy proposals and for matches whose policy was later
-    -# deleted, so it can't stand in for "these two agree" - only real classifications count.
-    - matched = suggestions.values.reject(&:error?).select { |s| s.match == "existing" && s.policy_id }
-    - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
-    - linked_votes = division.policy_divisions.pluck(:policy_id, :vote).to_h
-    - model_count = known_models.size
-    - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
-    - unanimous_suggestion = suggestions.values.find { |s| s.policy_id == unanimous_policy_id } if unanimous_policy_id
-    - unanimous_policy = unanimous_suggestion&.policy
+  - ai = DivisionAiSuggestions.new(division)
+  - if ai.any?
     %section.page-section#ai-policy-suggestions
       %h2.h5
         We have AI suggestions (staff only) -
@@ -24,49 +12,45 @@
       #ai-policy-suggestions-body.collapse
         %p.text-muted
           Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
-        - known_models.each do |model_id, label|
-          - suggestion = suggestions[model_id]
-          .ai-policy-suggestion{class: "ai-policy-suggestion-#{suggestion ? suggestion.outcome : 'unclassified'}"}
-            %h3.h3= label
-            - if suggestion.nil?
+        - ai.each do |row|
+          .ai-policy-suggestion{class: row.css_class}
+            %h3.h3= row.label
+            - if row.unclassified?
               %p.text-muted Not yet classified.
-            - elsif suggestion.error?
-              %p.text-danger= suggestion.summary
+            - elsif row.error?
+              %p.text-danger= row.summary
             - else
-              - vote_class = suggestion.direction == "for" ? "voted-aye" : "voted-no"
-              - suggested_vote = suggestion.direction == "for" ? "aye" : "no"
-              - linked_vote = linked_votes[suggestion.policy_id]
-              - agree_count = agreement[[suggestion.policy_id, suggestion.direction]].to_i
               %p
                 This vote is
-                %span.division-policy-statement-vote{class: vote_class}= suggestion.direction
-                - if suggestion.match == "new"
+                %span.division-policy-statement-vote{class: row.vote_class}= row.direction
+                - if row.new_policy?
                   a new policy:
-                  %strong= suggestion.proposed_policy_name
-                - elsif suggestion.policy
+                  %strong= row.proposed_policy_name
+                - elsif row.policy
                   an existing policy:
-                  = link_to suggestion.policy.name, suggestion.policy
+                  = link_to row.policy.name, row.policy
                 - else
                   = AiPolicySuggestion::POLICY_NOT_FOUND
 
-                - if agree_count > 1
-                  %span.label.label-info= "#{agree_count} models agree"
-                - if linked_vote && PolicyDivision.vote_without_strong(linked_vote) == suggested_vote
+                - if row.agreement?
+                  %span.label.label-info= "#{row.agree_count} models agree"
+                - if row.linked_same_way?
                   %span.label.label-success Already linked
-                - elsif linked_vote
+                - elsif row.linked_other_way?
                   %span.label.label-warning Linked the other way
-              - if suggestion.match == "new" && suggestion.proposed_policy_description.present?
-                %p= suggestion.proposed_policy_description
-              - if suggestion.reasoning.present?
-                %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
-        - if unanimous_policy && !linked_votes.key?(unanimous_policy.id)
+              - if row.new_policy? && row.proposed_policy_description.present?
+                %p= row.proposed_policy_description
+              - if row.reasoning.present?
+                %p.ai-policy-suggestion-reasoning.text-muted.small= row.reasoning
+        - unanimous = ai.unanimous
+        - if unanimous
           .ai-policy-suggestions-unanimous.alert.alert-info
             %p
-              All #{model_count.to_words} models agree this division is
-              = unanimous_direction
-              = link_to unanimous_policy.name, unanimous_policy
+              All #{ai.model_count.to_words} models agree this division is
+              = unanimous.direction
+              = link_to unanimous.policy.name, unanimous.policy
             - create_url = create_policy_division_path(division.url_params)
             = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
-              = f.hidden_field :policy_id, value: unanimous_policy.id
-              = f.hidden_field :vote, value: (unanimous_direction == "for" ? "aye" : "no")
-              = f.submit "Link this division to #{unanimous_policy.name}", class: "btn btn-primary btn-sm"
+              = f.hidden_field :policy_id, value: unanimous.policy.id
+              = f.hidden_field :vote, value: unanimous.vote
+              = f.submit "Link this division to #{unanimous.policy.name}", class: "btn btn-primary btn-sm"

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -47,7 +47,7 @@
                   an existing policy:
                   = link_to suggestion.policy.name, suggestion.policy
                 - else
-                  a policy that has since been deleted
+                  = AiPolicySuggestion::POLICY_NOT_FOUND
 
                 - if agree_count > 1
                   %span.label.label-info= "#{agree_count} models agree"

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,6 +1,7 @@
 - suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model)
 - if policy(division).edit? && suggestions.any?
   - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
+  - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
   %section.page-section#ai-policy-suggestions
     %h4
       We have AI suggestions (staff only) -
@@ -20,9 +21,16 @@
             %p.text-danger= "Error: #{suggestion.error}"
           - else
             %p
-              = suggestion.summary
+              - if suggestion.match == "existing" && suggestion.policy
+                = link_to suggestion.summary, suggestion.policy
+              - else
+                new policy:
+                = suggestion.summary
+
               - if suggestion.match == "existing" && agreement[[suggestion.policy_id, suggestion.direction]].to_i > 1
                 %span.label.label-info= "#{agreement[[suggestion.policy_id, suggestion.direction]]} models agree"
+              - if suggestion.match == "existing" && linked_policy_ids.include?(suggestion.policy_id)
+                %span.label.label-success Already linked
             - if suggestion.match == "new"
               %p
                 %strong= suggestion.proposed_policy_name

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,68 +1,72 @@
--# Only models the panel can label: a suggestion left over from a model id since retired from
--# MODEL_LABELS shouldn't count towards agreement nobody can see it taking part in.
-- known_models = DivisionPolicyClassifier::MODEL_LABELS
-- suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model).slice(*known_models.keys)
-- if policy(division).edit? && suggestions.any?
-  -# policy_id is nil both for new-policy proposals and for matches whose policy was later deleted, so
-  -# it can't stand in for "these two agree" - only suggestions naming a real policy are counted.
-  - matched = suggestions.values.reject(&:error?).select { |s| s.match == "existing" && s.policy_id }
-  - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
-  - linked_votes = division.policy_divisions.pluck(:policy_id, :vote).to_h
-  - model_count = known_models.size
-  - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
-  - unanimous_policy = suggestions.values.find { |s| s.policy_id == unanimous_policy_id }&.policy if unanimous_policy_id
-  %section.page-section#ai-policy-suggestions
-    %h2.h5
-      We have AI suggestions (staff only) -
-      %a.collapsed{href: "#ai-policy-suggestions-body", role: "button", data: {toggle: "collapse"}, "aria-expanded" => "false", "aria-controls" => "ai-policy-suggestions-body"}
-        %span.when-collapsed ▼ review
-        %span.when-expanded ▲ hide
-    #ai-policy-suggestions-body.collapse
-      %p.text-muted
-        Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
-      - known_models.each do |model_id, label|
-        - suggestion = suggestions[model_id]
-        .ai-policy-suggestion{class: "ai-policy-suggestion-#{suggestion ? suggestion.outcome : 'unclassified'}"}
-          %h3.h3= label
-          - if suggestion.nil?
-            %p.text-muted Not yet classified.
-          - elsif suggestion.error?
-            %p.text-danger= suggestion.summary
-          - else
-            - vote_class = suggestion.direction == "for" ? "voted-aye" : "voted-no"
-            - suggested_vote = suggestion.direction == "for" ? "aye" : "no"
-            - linked_vote = linked_votes[suggestion.policy_id]
-            - agree_count = agreement[[suggestion.policy_id, suggestion.direction]].to_i
-            %p
-              This vote is
-              %span.division-policy-statement-vote{class: vote_class}= suggestion.direction
-              - if suggestion.match == "new"
-                a new policy:
-                %strong= suggestion.proposed_policy_name
-              - elsif suggestion.policy
-                an existing policy:
-                = link_to suggestion.policy.name, suggestion.policy
-              - else
-                a policy that has since been deleted
+-# Gated on the policy governing the connections this panel offers to make, not on editing the
+-# division, so widening who may edit a division can't publish unreviewed AI drafts.
+- if policy(PolicyDivision).new?
+  -# Only models the panel can label: a suggestion left over from a model id since retired from
+  -# MODEL_LABELS shouldn't count towards agreement nobody can see it taking part in.
+  - known_models = DivisionPolicyClassifier::MODEL_LABELS
+  - suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model).slice(*known_models.keys)
+  - if suggestions.any?
+    -# policy_id is nil both for new-policy proposals and for matches whose policy was later
+    -# deleted, so it can't stand in for "these two agree" - only real classifications count.
+    - matched = suggestions.values.reject(&:error?).select { |s| s.match == "existing" && s.policy_id }
+    - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
+    - linked_votes = division.policy_divisions.pluck(:policy_id, :vote).to_h
+    - model_count = known_models.size
+    - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
+    - unanimous_suggestion = suggestions.values.find { |s| s.policy_id == unanimous_policy_id } if unanimous_policy_id
+    - unanimous_policy = unanimous_suggestion&.policy
+    %section.page-section#ai-policy-suggestions
+      %h2.h5
+        We have AI suggestions (staff only) -
+        %a.collapsed{href: "#ai-policy-suggestions-body", role: "button", data: {toggle: "collapse"}, "aria-expanded" => "false", "aria-controls" => "ai-policy-suggestions-body"}
+          %span.when-collapsed ▼ review
+          %span.when-expanded ▲ hide
+      #ai-policy-suggestions-body.collapse
+        %p.text-muted
+          Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
+        - known_models.each do |model_id, label|
+          - suggestion = suggestions[model_id]
+          .ai-policy-suggestion{class: "ai-policy-suggestion-#{suggestion ? suggestion.outcome : 'unclassified'}"}
+            %h3.h3= label
+            - if suggestion.nil?
+              %p.text-muted Not yet classified.
+            - elsif suggestion.error?
+              %p.text-danger= suggestion.summary
+            - else
+              - vote_class = suggestion.direction == "for" ? "voted-aye" : "voted-no"
+              - suggested_vote = suggestion.direction == "for" ? "aye" : "no"
+              - linked_vote = linked_votes[suggestion.policy_id]
+              - agree_count = agreement[[suggestion.policy_id, suggestion.direction]].to_i
+              %p
+                This vote is
+                %span.division-policy-statement-vote{class: vote_class}= suggestion.direction
+                - if suggestion.match == "new"
+                  a new policy:
+                  %strong= suggestion.proposed_policy_name
+                - elsif suggestion.policy
+                  an existing policy:
+                  = link_to suggestion.policy.name, suggestion.policy
+                - else
+                  a policy that has since been deleted
 
-              - if agree_count > 1
-                %span.label.label-info= "#{agree_count} models agree"
-              - if linked_vote && PolicyDivision.vote_without_strong(linked_vote) == suggested_vote
-                %span.label.label-success Already linked
-              - elsif linked_vote
-                %span.label.label-warning Linked the other way
-            - if suggestion.match == "new" && suggestion.proposed_policy_description.present?
-              %p.ai-policy-suggestion-proposal= suggestion.proposed_policy_description
-            - if suggestion.reasoning.present?
-              %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
-      - if unanimous_policy && policy(PolicyDivision).new? && !linked_votes.key?(unanimous_policy.id)
-        .ai-policy-suggestions-unanimous.alert.alert-info
-          %p
-            All #{model_count.to_words} models agree this division is
-            = unanimous_direction
-            = link_to unanimous_policy.name, unanimous_policy
-          - create_url = create_policy_division_path(division.url_params)
-          = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
-            = f.hidden_field :policy_id, value: unanimous_policy.id
-            = f.hidden_field :vote, value: (unanimous_direction == "for" ? "aye" : "no")
-            = f.submit "Link this division to #{unanimous_policy.name}", class: "btn btn-primary btn-sm"
+                - if agree_count > 1
+                  %span.label.label-info= "#{agree_count} models agree"
+                - if linked_vote && PolicyDivision.vote_without_strong(linked_vote) == suggested_vote
+                  %span.label.label-success Already linked
+                - elsif linked_vote
+                  %span.label.label-warning Linked the other way
+              - if suggestion.match == "new" && suggestion.proposed_policy_description.present?
+                %p= suggestion.proposed_policy_description
+              - if suggestion.reasoning.present?
+                %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
+        - if unanimous_policy && !linked_votes.key?(unanimous_policy.id)
+          .ai-policy-suggestions-unanimous.alert.alert-info
+            %p
+              All #{model_count.to_words} models agree this division is
+              = unanimous_direction
+              = link_to unanimous_policy.name, unanimous_policy
+            - create_url = create_policy_division_path(division.url_params)
+            = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
+              = f.hidden_field :policy_id, value: unanimous_policy.id
+              = f.hidden_field :vote, value: (unanimous_direction == "for" ? "aye" : "no")
+              = f.submit "Link this division to #{unanimous_policy.name}", class: "btn btn-primary btn-sm"

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -23,10 +23,12 @@
             %p.text-danger= suggestion.summary
           - else
             %p
-              - if suggestion.match == "existing" && suggestion.policy
+              - if suggestion.match == "new"
+                new policy:
+                = suggestion.summary
+              - elsif suggestion.policy
                 = link_to suggestion.summary, suggestion.policy
               - else
-                new policy:
                 = suggestion.summary
 
               - if suggestion.match == "existing" && agreement[[suggestion.policy_id, suggestion.direction]].to_i > 1

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -2,6 +2,8 @@
 - if policy(division).edit? && suggestions.any?
   - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
   - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
+  - unanimous_policy_id, unanimous_direction = agreement.find { |_, count| count == DivisionPolicyClassifier::MODEL_LABELS.size }&.first
+  - unanimous_policy = Policy.find_by(id: unanimous_policy_id) if unanimous_policy_id
   %section.page-section#ai-policy-suggestions
     %h4
       We have AI suggestions (staff only) -
@@ -37,3 +39,13 @@
                 = suggestion.proposed_policy_description
             - if suggestion.reasoning.present?
               %p.text-muted= suggestion.reasoning
+      - if unanimous_policy && policy(PolicyDivision).new? && !linked_policy_ids.include?(unanimous_policy.id)
+        .ai-policy-suggestions-unanimous.alert.alert-info
+          %p
+            All three models agree this division is
+            = unanimous_direction
+            = link_to unanimous_policy.name, unanimous_policy
+          = simple_form_for :policy_division, url: create_policy_division_path(division.url_params), html: {class: "form-inline"} do |f|
+            = f.hidden_field :policy_id, value: unanimous_policy.id
+            = f.hidden_field :vote, value: (unanimous_direction == "for" ? "aye" : "no")
+            = f.submit "Link this division to #{unanimous_policy.name}", class: "btn btn-primary btn-sm"

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -1,11 +1,14 @@
-- suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model)
+-# Only models the panel can label: a suggestion left over from a model id since retired from
+-# MODEL_LABELS shouldn't count towards agreement nobody can see it taking part in.
+- known_models = DivisionPolicyClassifier::MODEL_LABELS
+- suggestions = division.ai_policy_suggestions.includes(:policy).index_by(&:model).slice(*known_models.keys)
 - if policy(division).edit? && suggestions.any?
   -# policy_id is nil both for new-policy proposals and for matches whose policy was later deleted, so
   -# it can't stand in for "these two agree" - only suggestions naming a real policy are counted.
   - matched = suggestions.values.select { |s| s.match == "existing" && s.policy_id && s.direction }
   - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
   - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
-  - model_count = DivisionPolicyClassifier::MODEL_LABELS.size
+  - model_count = known_models.size
   - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
   - unanimous_policy = suggestions.values.find { |s| s.policy_id == unanimous_policy_id }&.policy if unanimous_policy_id
   %section.page-section#ai-policy-suggestions
@@ -17,7 +20,7 @@
     #ai-policy-suggestions-body.collapse
       %p.text-muted
         Draft proposals from AI models classifying this division against existing policies, not yet reviewed by a human.
-      - DivisionPolicyClassifier::MODEL_LABELS.each do |model_id, label|
+      - known_models.each do |model_id, label|
         - suggestion = suggestions[model_id]
         .ai-policy-suggestion{class: "ai-policy-suggestion-#{suggestion ? suggestion.outcome : 'unclassified'}"}
           %h3.h3= label

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -42,15 +42,4 @@
                 %p= row.proposed_policy_description
               - if row.reasoning.present?
                 %p.ai-policy-suggestion-reasoning.text-muted.small= row.reasoning
-        - unanimous = ai.unanimous
-        - if unanimous
-          .ai-policy-suggestions-unanimous.alert.alert-info
-            %p
-              All #{ai.model_count.to_words} models agree this division is
-              = unanimous.direction
-              = link_to unanimous.policy.name, unanimous.policy
-            - create_url = create_policy_division_path(division.url_params)
-            = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
-              = f.hidden_field :policy_id, value: unanimous.policy.id
-              = f.hidden_field :vote, value: unanimous.vote
-              = f.submit "Link this division to #{unanimous.policy.name}", class: "btn btn-primary btn-sm"
+        = render "ai_unanimous_suggestion", division: division, ai: ai if ai.unanimous

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -2,8 +2,9 @@
 - if policy(division).edit? && suggestions.any?
   - agreement = suggestions.values.select { |s| s.match == "existing" && s.direction }.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
   - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
-  - unanimous_policy_id, unanimous_direction = agreement.find { |_, count| count == DivisionPolicyClassifier::MODEL_LABELS.size }&.first
-  - unanimous_policy = Policy.find_by(id: unanimous_policy_id) if unanimous_policy_id
+  - model_count = DivisionPolicyClassifier::MODEL_LABELS.size
+  - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
+  - unanimous_policy = suggestions.values.find { |s| s.policy_id == unanimous_policy_id }&.policy if unanimous_policy_id
   %section.page-section#ai-policy-suggestions
     %h2.h5
       We have AI suggestions (staff only) -
@@ -44,10 +45,11 @@
       - if unanimous_policy && policy(PolicyDivision).new? && !linked_policy_ids.include?(unanimous_policy.id)
         .ai-policy-suggestions-unanimous.alert.alert-info
           %p
-            All three models agree this division is
+            All #{model_count.to_words} models agree this division is
             = unanimous_direction
             = link_to unanimous_policy.name, unanimous_policy
-          = simple_form_for :policy_division, url: create_policy_division_path(division.url_params), html: {class: "form-inline"} do |f|
+          - create_url = create_policy_division_path(division.url_params)
+          = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
             = f.hidden_field :policy_id, value: unanimous_policy.id
             = f.hidden_field :vote, value: (unanimous_direction == "for" ? "aye" : "no")
             = f.submit "Link this division to #{unanimous_policy.name}", class: "btn btn-primary btn-sm"

--- a/app/views/divisions/_ai_policy_suggestions.html.haml
+++ b/app/views/divisions/_ai_policy_suggestions.html.haml
@@ -5,9 +5,9 @@
 - if policy(division).edit? && suggestions.any?
   -# policy_id is nil both for new-policy proposals and for matches whose policy was later deleted, so
   -# it can't stand in for "these two agree" - only suggestions naming a real policy are counted.
-  - matched = suggestions.values.select { |s| s.match == "existing" && s.policy_id && s.direction }
+  - matched = suggestions.values.reject(&:error?).select { |s| s.match == "existing" && s.policy_id }
   - agreement = matched.group_by { |s| [s.policy_id, s.direction] }.transform_values(&:size)
-  - linked_policy_ids = division.policy_divisions.pluck(:policy_id)
+  - linked_votes = division.policy_divisions.pluck(:policy_id, :vote).to_h
   - model_count = known_models.size
   - unanimous_policy_id, unanimous_direction = agreement.key(model_count)
   - unanimous_policy = suggestions.values.find { |s| s.policy_id == unanimous_policy_id }&.policy if unanimous_policy_id
@@ -30,6 +30,9 @@
             %p.text-danger= suggestion.summary
           - else
             - vote_class = suggestion.direction == "for" ? "voted-aye" : "voted-no"
+            - suggested_vote = suggestion.direction == "for" ? "aye" : "no"
+            - linked_vote = linked_votes[suggestion.policy_id]
+            - agree_count = agreement[[suggestion.policy_id, suggestion.direction]].to_i
             %p
               This vote is
               %span.division-policy-statement-vote{class: vote_class}= suggestion.direction
@@ -42,15 +45,17 @@
               - else
                 a policy that has since been deleted
 
-              - if suggestion.match == "existing" && agreement[[suggestion.policy_id, suggestion.direction]].to_i > 1
-                %span.label.label-info= "#{agreement[[suggestion.policy_id, suggestion.direction]]} models agree"
-              - if suggestion.match == "existing" && linked_policy_ids.include?(suggestion.policy_id)
+              - if agree_count > 1
+                %span.label.label-info= "#{agree_count} models agree"
+              - if linked_vote && PolicyDivision.vote_without_strong(linked_vote) == suggested_vote
                 %span.label.label-success Already linked
+              - elsif linked_vote
+                %span.label.label-warning Linked the other way
             - if suggestion.match == "new" && suggestion.proposed_policy_description.present?
               %p.ai-policy-suggestion-proposal= suggestion.proposed_policy_description
             - if suggestion.reasoning.present?
               %p.ai-policy-suggestion-reasoning.text-muted.small= suggestion.reasoning
-      - if unanimous_policy && policy(PolicyDivision).new? && !linked_policy_ids.include?(unanimous_policy.id)
+      - if unanimous_policy && policy(PolicyDivision).new? && !linked_votes.key?(unanimous_policy.id)
         .ai-policy-suggestions-unanimous.alert.alert-info
           %p
             All #{model_count.to_words} models agree this division is

--- a/app/views/divisions/_ai_unanimous_suggestion.html.haml
+++ b/app/views/divisions/_ai_unanimous_suggestion.html.haml
@@ -1,0 +1,14 @@
+-# Shown only when every model matched the same existing policy in the same direction and nothing
+-# links the division to it yet - see DivisionAiSuggestions#unanimous. Posts to the same endpoint,
+-# with the same authorization, as the manual "connect a policy" form on the policies page.
+- unanimous = ai.unanimous
+.ai-policy-suggestions-unanimous.alert.alert-info
+  %p
+    All #{ai.model_count.to_words} models agree this division is
+    = unanimous.direction
+    = link_to unanimous.policy.name, unanimous.policy
+  - create_url = create_policy_division_path(division.url_params)
+  = simple_form_for :policy_division, url: create_url, html: {class: "form-inline"} do |f|
+    = f.hidden_field :policy_id, value: unanimous.policy.id
+    = f.hidden_field :vote, value: unanimous.vote
+    = f.submit "Link this division to #{unanimous.policy.name}", class: "btn btn-primary btn-sm"

--- a/app/views/divisions/show.html.haml
+++ b/app/views/divisions/show.html.haml
@@ -13,6 +13,7 @@
     =render "layouts/history_notice", policy: nil, division: @division
 
 = render "header", division: @division
+= render "ai_policy_suggestions", division: @division
 = render "social_share"
 = render "motion", division: @division
 = render "external_links", division: @division

--- a/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2006-12-06/3.html
@@ -80,6 +80,7 @@ Prohibition of Human Cloning for Reproduction and the Regulation of Human Embryo
 </h1>
 </div>
 
+
 <aside class='social-share'>
 <h2 class='social-share-heading small'>
 Share

--- a/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/representatives/2013-03-14/1.html
@@ -80,6 +80,7 @@ test
 </h1>
 </div>
 
+
 <aside class='social-share'>
 <h2 class='social-share-heading small'>
 Share

--- a/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
+++ b/spec/fixtures/static_pages/divisions/senate/2009-11-25/8.html
@@ -98,6 +98,7 @@ A lovely new title
 </h1>
 </div>
 
+
 <aside class='social-share'>
 <h2 class='social-share-heading small'>
 Share

--- a/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
+++ b/spec/fixtures/static_pages/divisions/senate/2013-03-14/1.html
@@ -72,6 +72,7 @@ Motions — Renewable Energy Certificates
 </h1>
 </div>
 
+
 <aside class='social-share'>
 <h2 class='social-share-heading small'>
 Share

--- a/spec/lib/division_ai_suggestions_spec.rb
+++ b/spec/lib/division_ai_suggestions_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe DivisionAiSuggestions do
+  subject(:panel) { described_class.new(division) }
+
+  let(:division) { create(:division) }
+  let(:policy) { create(:policy, name: "marriage equality") }
+  let(:model_ids) { DivisionPolicyClassifier::MODEL_LABELS.keys }
+
+  def rows
+    panel.each.to_a
+  end
+
+  def suggest(model_id, **attributes)
+    create(:ai_policy_suggestion, { division: division, model: model_id }.merge(attributes))
+  end
+
+  describe "#any?" do
+    it "is false when no model has classified the division" do
+      expect(panel.any?).to be false
+    end
+
+    it "is true once a model has" do
+      suggest(model_ids.first, policy: policy)
+      expect(panel.any?).to be true
+    end
+
+    it "ignores suggestions from models the panel can't label" do
+      suggest("retired.model-v1", policy: policy)
+      expect(panel.any?).to be false
+    end
+  end
+
+  describe "#each" do
+    it "yields a row per model the panel knows about, whether or not it has run" do
+      suggest(model_ids.first, policy: policy)
+
+      expect(rows.map(&:label)).to eq DivisionPolicyClassifier::MODEL_LABELS.values
+      expect(rows.first).not_to be_unclassified
+      expect(rows.last).to be_unclassified
+    end
+  end
+
+  describe "agreement" do
+    it "counts models that matched the same policy in the same direction" do
+      model_ids.first(2).each { |id| suggest(id, policy: policy, direction: "for") }
+      suggest(model_ids.last, policy: policy, direction: "against")
+
+      expect(rows.map(&:agree_count)).to eq [2, 2, 1]
+      expect(rows.first).to be_agreement
+      expect(rows.last).not_to be_agreement
+    end
+
+    it "doesn't treat suggestions naming no policy as agreeing with each other" do
+      model_ids.each { |id| suggest(id, policy: policy, direction: "for") }
+      policy.destroy!
+
+      expect(rows.map(&:agree_count)).to eq [0, 0, 0]
+    end
+  end
+
+  describe "already-linked state" do
+    before { model_ids.each { |id| suggest(id, policy: policy, direction: "for") } }
+
+    it "reports a connection recorded in the same direction" do
+      create(:policy_division, division: division, policy: policy, vote: "aye")
+
+      expect(rows.first).to be_linked_same_way
+      expect(rows.first).not_to be_linked_other_way
+    end
+
+    it "reports a connection recorded the other way, strong votes included" do
+      create(:policy_division, division: division, policy: policy, vote: "no3")
+
+      expect(rows.first).to be_linked_other_way
+      expect(rows.first).not_to be_linked_same_way
+    end
+
+    it "reports neither when nothing is linked" do
+      expect(rows.first).not_to be_linked_same_way
+      expect(rows.first).not_to be_linked_other_way
+    end
+  end
+
+  describe "#unanimous" do
+    it "names the policy and direction when every model agrees" do
+      model_ids.each { |id| suggest(id, policy: policy, direction: "against") }
+
+      expect(panel.unanimous.policy).to eq policy
+      expect(panel.unanimous.direction).to eq "against"
+      expect(panel.unanimous.vote).to eq "no"
+    end
+
+    it "translates a for direction into an aye vote" do
+      model_ids.each { |id| suggest(id, policy: policy, direction: "for") }
+
+      expect(panel.unanimous.vote).to eq "aye"
+    end
+
+    it "is nil when only some of the models agree" do
+      model_ids.first(2).each { |id| suggest(id, policy: policy, direction: "for") }
+      suggest(model_ids.last, policy: policy, direction: "against")
+
+      expect(panel.unanimous).to be_nil
+    end
+
+    it "is nil when the division is already linked to that policy" do
+      model_ids.each { |id| suggest(id, policy: policy, direction: "for") }
+      create(:policy_division, division: division, policy: policy, vote: "aye")
+
+      expect(panel.unanimous).to be_nil
+    end
+
+    it "is nil when an unknown model makes up the numbers" do
+      model_ids.first(2).each { |id| suggest(id, policy: policy, direction: "for") }
+      suggest("retired.model-v1", policy: policy, direction: "for")
+
+      expect(panel.unanimous).to be_nil
+    end
+  end
+
+  describe "row css_class" do
+    it "names the outcome, or says the model hasn't run" do
+      suggest(model_ids.first, policy: policy, match: "existing")
+      suggest(model_ids[1], policy: nil, match: "new")
+      suggest(model_ids.last, policy: policy, match: nil, direction: nil)
+
+      expect(rows.map(&:css_class)).to eq %w[
+        ai-policy-suggestion-existing
+        ai-policy-suggestion-new
+        ai-policy-suggestion-error
+      ]
+    end
+
+    it "says unclassified for a model that hasn't run" do
+      suggest(model_ids.first, policy: policy)
+
+      expect(rows.last.css_class).to eq "ai-policy-suggestion-unclassified"
+    end
+  end
+end

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -76,4 +76,21 @@ describe AiPolicySuggestion do
       expect(suggestion.summary).to eq "Error: model response was missing match/direction"
     end
   end
+
+  describe "#error?" do
+    it "is true when the error column is set" do
+      suggestion = build(:ai_policy_suggestion, error: "boom")
+      expect(suggestion.error?).to be true
+    end
+
+    it "is true when match/direction are missing, even without an error column" do
+      suggestion = build(:ai_policy_suggestion, match: nil, direction: nil, error: nil)
+      expect(suggestion.error?).to be true
+    end
+
+    it "is false for a normal classification" do
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", error: nil)
+      expect(suggestion.error?).to be false
+    end
+  end
 end

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -96,5 +96,12 @@ describe AiPolicySuggestion do
       suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", error: nil)
       expect(suggestion.error?).to be false
     end
+
+    it "agrees with #summary on a blank error, treating it as no error at all" do
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", error: "")
+
+      expect(suggestion.error?).to be false
+      expect(suggestion.summary).not_to start_with "Error:"
+    end
   end
 end

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -56,9 +56,13 @@ describe AiPolicySuggestion do
       expect(suggestion.summary).to eq "For policy 42 (marriage equality)"
     end
 
-    it "falls back to just the id if the matched policy has since been deleted" do
-      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "against", policy: nil, policy_id: 42)
-      expect(suggestion.summary).to eq "Against policy 42"
+    it "says so when the matched policy has since been deleted" do
+      policy = create(:policy)
+      suggestion = create(:ai_policy_suggestion, match: "existing", direction: "against", policy: policy)
+
+      policy.destroy!
+
+      expect(suggestion.reload.summary).to eq "Against a policy that has since been deleted"
     end
 
     it "says a new policy was proposed" do

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -52,8 +52,13 @@ describe AiPolicySuggestion do
 
   describe "#summary" do
     it "names the matched policy and direction" do
-      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", policy: build(:policy, id: 42))
-      expect(suggestion.summary).to eq "For policy 42"
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", policy: build(:policy, id: 42, name: "marriage equality"))
+      expect(suggestion.summary).to eq "For policy 42 (marriage equality)"
+    end
+
+    it "falls back to just the id if the matched policy has since been deleted" do
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "against", policy: nil, policy_id: 42)
+      expect(suggestion.summary).to eq "Against policy 42"
     end
 
     it "says a new policy was proposed" do

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -56,13 +56,19 @@ describe AiPolicySuggestion do
       expect(suggestion.summary).to eq "For policy 42 (marriage equality)"
     end
 
-    it "says so when the matched policy has since been deleted" do
+    it "says the policy can't be found when the matched policy has since been deleted" do
       policy = create(:policy)
       suggestion = create(:ai_policy_suggestion, match: "existing", direction: "against", policy: policy)
 
       policy.destroy!
 
-      expect(suggestion.reload.summary).to eq "Against a policy that has since been deleted"
+      expect(suggestion.reload.summary).to eq "Against a policy that can no longer be found"
+    end
+
+    it "says the policy can't be found when the model named one that never resolved" do
+      suggestion = build(:ai_policy_suggestion, match: "existing", direction: "for", policy: nil)
+
+      expect(suggestion.summary).to eq "For a policy that can no longer be found"
     end
 
     it "says a new policy was proposed" do

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -122,6 +122,18 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("the government should ban things")
     end
 
+    it "ignores a stored suggestion from a model the panel no longer knows about" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: "retired.model-v1", direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("2 models agree")
+      expect(response.body).not_to include("Link this division to")
+    end
+
     it "doesn't count suggestions as agreeing once the policy they named has been deleted" do
       login_as(user)
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -127,7 +127,7 @@ describe DivisionsController, type: :request do
       policy1.destroy!
       get "/divisions/representatives/2006-12-06/3"
 
-      expect(response.body).to include("a policy that has since been deleted")
+      expect(response.body).to include("a policy that can no longer be found")
       expect(response.body).not_to include(%(href="#{policy_path(policy1)}"))
     end
 

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -76,6 +76,25 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("We have AI suggestions")
       expect(response.body).to include("review")
     end
+
+    it "links a suggestion's summary to the policy it matched" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include(%(href="#{policy_path(policy1)}"))
+    end
+
+    it "shows a suggestion as already linked when the division's already connected to that policy" do
+      login_as(user)
+      create(:policy_division, division: division_representatives_2006_12_06_3, policy: policy1, vote: "aye")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("Already linked")
+    end
   end
 
   describe "#index" do

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -95,6 +95,16 @@ describe DivisionsController, type: :request do
 
       expect(response.body).to include("Already linked")
     end
+
+    it "styles a suggestion with no match/direction as an error, rather than a misleading new-policy line" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, match: nil, direction: nil, error: nil)
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("<p class='text-danger'>Error: model response was missing match/direction</p>")
+      expect(response.body).not_to include("new policy:")
+    end
   end
 
   describe "#index" do

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -66,6 +66,16 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("Claude Haiku 4.5")
       expect(response.body.scan("models agree").size).to eq(2)
     end
+
+    it "labels the section so staff know to click it to review the suggestions" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi)
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("We have AI suggestions")
+      expect(response.body).to include("review")
+    end
   end
 
   describe "#index" do

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -96,9 +96,22 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("Already linked")
     end
 
+    it "doesn't call an existing match a new policy when the matched policy has been deleted" do
+      login_as(user)
+      division = division_representatives_2006_12_06_3
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, match: "existing", direction: "for")
+
+      policy1.destroy!
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("For a policy that has since been deleted")
+      expect(response.body).not_to include("new policy:")
+    end
+
     it "styles a suggestion with no match/direction as an error, rather than a misleading new-policy line" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, match: nil, direction: nil, error: nil)
+      division = division_representatives_2006_12_06_3
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, match: nil, direction: nil, error: nil)
 
       get "/divisions/representatives/2006-12-06/3"
 

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -109,6 +109,18 @@ describe DivisionsController, type: :request do
       expect(response.body).not_to include("new policy:")
     end
 
+    it "doesn't count suggestions as agreeing once the policy they named has been deleted" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "for")
+
+      policy1.destroy!
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).not_to include("models agree")
+    end
+
     it "styles a suggestion with no match/direction as an error, rather than a misleading new-policy line" do
       login_as(user)
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi,

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -105,6 +105,52 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("<p class='text-danger'>Error: model response was missing match/direction</p>")
       expect(response.body).not_to include("new policy:")
     end
+
+    it "offers staff a quick link to the policy when all three models agree" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("Link this division to marriage equality")
+    end
+
+    it "doesn't offer a quick link when only two of the three models agree" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "against")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).not_to include("Link this division to")
+    end
+
+    it "doesn't offer a quick link when the division's already linked to that policy" do
+      login_as(user)
+      create(:policy_division, division: division_representatives_2006_12_06_3, policy: policy1, vote: "aye")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).not_to include("Link this division to")
+    end
+
+    it "actually links the division to the policy when the quick link button is submitted" do
+      login_as(user)
+      division = division_representatives_2006_12_06_3
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "for")
+
+      post "/divisions/representatives/2006-12-06/3/policies/create", params: { policy_division: { policy_id: policy1.id, vote: "aye" } }
+
+      expect(division.policy_divisions.find_by(policy: policy1)&.vote).to eq "aye"
+    end
   end
 
   describe "#index" do

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -99,6 +99,17 @@ describe DivisionsController, type: :request do
       expect(response.body).to include("Already linked")
     end
 
+    it "flags a suggestion that contradicts the direction the division is already linked with" do
+      login_as(user)
+      create(:policy_division, division: division, policy: policy1, vote: "no3")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("Linked the other way")
+      expect(response.body).not_to include("Already linked")
+    end
+
     it "doesn't call an existing match a new policy when the matched policy has been deleted" do
       login_as(user)
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi,

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -85,6 +85,8 @@ describe DivisionsController, type: :request do
       get "/divisions/representatives/2006-12-06/3"
 
       expect(response.body).to include(%(href="#{policy_path(policy1)}"))
+      expect(response.body).to include("This vote is")
+      expect(response.body).to include("voted-aye")
     end
 
     it "shows a suggestion as already linked when the division's already connected to that policy" do
@@ -105,7 +107,7 @@ describe DivisionsController, type: :request do
       policy1.destroy!
       get "/divisions/representatives/2006-12-06/3"
 
-      expect(response.body).to include("For a policy that has since been deleted")
+      expect(response.body).to include("a policy that has since been deleted")
       expect(response.body).not_to include(%(href="#{policy_path(policy1)}"))
     end
 

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -54,6 +54,15 @@ describe DivisionsController, type: :request do
       expect(response.body).not_to include("ai-policy-suggestions")
     end
 
+    it "is hidden from a signed-in user who isn't staff" do
+      login_as(create(:confirmed_user, staff: false))
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi)
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).not_to include("ai-policy-suggestions")
+    end
+
     it "shows each model's proposal to staff, flagging agreement between models" do
       login_as(user)
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -35,9 +35,10 @@ describe DivisionsController, type: :request do
     let(:kimi) { "moonshotai.kimi-k2.5" }
     let(:deepseek) { "deepseek.v3.2" }
     let(:claude) { "au.anthropic.claude-haiku-4-5-20251001-v1:0" }
+    let(:division) { division_representatives_2006_12_06_3 }
 
     before do
-      division_representatives_2006_12_06_3
+      division
       policy1
     end
 
@@ -48,16 +49,16 @@ describe DivisionsController, type: :request do
     end
 
     it "is hidden from non-staff even when suggestions exist" do
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi)
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi)
       get "/divisions/representatives/2006-12-06/3"
       expect(response.body).not_to include("ai-policy-suggestions")
     end
 
     it "shows each model's proposal to staff, flagging agreement between models" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "against")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "against")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -69,7 +70,7 @@ describe DivisionsController, type: :request do
 
     it "labels the section so staff know to click it to review the suggestions" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi)
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi)
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -79,7 +80,7 @@ describe DivisionsController, type: :request do
 
     it "links a suggestion's summary to the policy it matched" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -88,8 +89,8 @@ describe DivisionsController, type: :request do
 
     it "shows a suggestion as already linked when the division's already connected to that policy" do
       login_as(user)
-      create(:policy_division, division: division_representatives_2006_12_06_3, policy: policy1, vote: "aye")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:policy_division, division: division, policy: policy1, vote: "aye")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -98,8 +99,8 @@ describe DivisionsController, type: :request do
 
     it "doesn't call an existing match a new policy when the matched policy has been deleted" do
       login_as(user)
-      division = division_representatives_2006_12_06_3
-      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, match: "existing", direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi,
+                                    match: "existing", direction: "for")
 
       policy1.destroy!
       get "/divisions/representatives/2006-12-06/3"
@@ -110,8 +111,8 @@ describe DivisionsController, type: :request do
 
     it "styles a suggestion with no match/direction as an error, rather than a misleading new-policy line" do
       login_as(user)
-      division = division_representatives_2006_12_06_3
-      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, match: nil, direction: nil, error: nil)
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi,
+                                    match: nil, direction: nil, error: nil)
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -121,9 +122,9 @@ describe DivisionsController, type: :request do
 
     it "offers staff a quick link to the policy when all three models agree" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "for")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -132,9 +133,9 @@ describe DivisionsController, type: :request do
 
     it "doesn't offer a quick link when only two of the three models agree" do
       login_as(user)
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "against")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "against")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -143,10 +144,10 @@ describe DivisionsController, type: :request do
 
     it "doesn't offer a quick link when the division's already linked to that policy" do
       login_as(user)
-      create(:policy_division, division: division_representatives_2006_12_06_3, policy: policy1, vote: "aye")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
-      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "for")
+      create(:policy_division, division: division, policy: policy1, vote: "aye")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "for")
 
       get "/divisions/representatives/2006-12-06/3"
 
@@ -155,12 +156,12 @@ describe DivisionsController, type: :request do
 
     it "actually links the division to the policy when the quick link button is submitted" do
       login_as(user)
-      division = division_representatives_2006_12_06_3
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi, direction: "for")
       create(:ai_policy_suggestion, division: division, policy: policy1, model: deepseek, direction: "for")
       create(:ai_policy_suggestion, division: division, policy: policy1, model: claude, direction: "for")
 
-      post "/divisions/representatives/2006-12-06/3/policies/create", params: { policy_division: { policy_id: policy1.id, vote: "aye" } }
+      params = { policy_division: { policy_id: policy1.id, vote: "aye" } }
+      post "/divisions/representatives/2006-12-06/3/policies/create", params: params
 
       expect(division.policy_divisions.find_by(policy: policy1)&.vote).to eq "aye"
     end

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -31,6 +31,43 @@ describe DivisionsController, type: :request do
     end
   end
 
+  describe "#show, AI policy suggestions" do
+    let(:kimi) { "moonshotai.kimi-k2.5" }
+    let(:deepseek) { "deepseek.v3.2" }
+    let(:claude) { "au.anthropic.claude-haiku-4-5-20251001-v1:0" }
+
+    before do
+      division_representatives_2006_12_06_3
+      policy1
+    end
+
+    it "is hidden when no model has classified the division yet, even for staff" do
+      login_as(user)
+      get "/divisions/representatives/2006-12-06/3"
+      expect(response.body).not_to include("ai-policy-suggestions")
+    end
+
+    it "is hidden from non-staff even when suggestions exist" do
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi)
+      get "/divisions/representatives/2006-12-06/3"
+      expect(response.body).not_to include("ai-policy-suggestions")
+    end
+
+    it "shows each model's proposal to staff, flagging agreement between models" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: kimi, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: deepseek, direction: "for")
+      create(:ai_policy_suggestion, division: division_representatives_2006_12_06_3, policy: policy1, model: claude, direction: "against")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("Kimi K2.5")
+      expect(response.body).to include("DeepSeek V3.2")
+      expect(response.body).to include("Claude Haiku 4.5")
+      expect(response.body.scan("models agree").size).to eq(2)
+    end
+  end
+
   describe "#index" do
     before do
       division_representatives_2006_12_06_3

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -106,7 +106,18 @@ describe DivisionsController, type: :request do
       get "/divisions/representatives/2006-12-06/3"
 
       expect(response.body).to include("For a policy that has since been deleted")
-      expect(response.body).not_to include("new policy:")
+      expect(response.body).not_to include(%(href="#{policy_path(policy1)}"))
+    end
+
+    it "shows the name and description of a proposed new policy" do
+      login_as(user)
+      create(:ai_policy_suggestion, division: division, policy: nil, model: kimi, match: "new", direction: "for",
+                                    proposed_policy_name: "banning things", proposed_policy_description: "the government should ban things")
+
+      get "/divisions/representatives/2006-12-06/3"
+
+      expect(response.body).to include("banning things")
+      expect(response.body).to include("the government should ban things")
     end
 
     it "doesn't count suggestions as agreeing once the policy they named has been deleted" do
@@ -121,7 +132,7 @@ describe DivisionsController, type: :request do
       expect(response.body).not_to include("models agree")
     end
 
-    it "styles a suggestion with no match/direction as an error, rather than a misleading new-policy line" do
+    it "styles a suggestion with no match/direction as an error, rather than an ordinary classification" do
       login_as(user)
       create(:ai_policy_suggestion, division: division, policy: policy1, model: kimi,
                                     match: nil, direction: nil, error: nil)
@@ -129,7 +140,7 @@ describe DivisionsController, type: :request do
       get "/divisions/representatives/2006-12-06/3"
 
       expect(response.body).to include("<p class='text-danger'>Error: model response was missing match/direction</p>")
-      expect(response.body).not_to include("new policy:")
+      expect(response.body).not_to include(%(href="#{policy_path(policy1)}"))
     end
 
     it "offers staff a quick link to the policy when all three models agree" do

--- a/spec/services/division_policy_classifier_spec.rb
+++ b/spec/services/division_policy_classifier_spec.rb
@@ -23,6 +23,13 @@ describe DivisionPolicyClassifier do
     stubbed_client.stub_responses(:converse, converse_response(text))
   end
 
+  # MODELS says which models to call, MODEL_LABELS says how to name them on the division page, and
+  # they're maintained by hand. A model in one and not the other either never gets displayed or
+  # never gets called, with nothing else failing to say so.
+  it "labels every model it classifies with" do
+    expect(described_class::MODEL_LABELS.keys).to match_array(described_class::MODELS.values)
+  end
+
   describe "#classify_with" do
     it "matches an existing policy" do
       policy = create(:policy)


### PR DESCRIPTION

<img width="1199" height="1082" alt="image" src="https://github.com/user-attachments/assets/a5064508-45d8-4370-bee3-28a7269a6b58" />

## What and why

Adds a staff-only, collapsed-by-default panel to a division's page showing each of the three Bedrock models' draft policy classification for that division: which policy it matched (or the new policy it proposes), the direction, and its reasoning. Only renders once at least one model has actually classified the division. Flags when two or more models land on the same existing policy and direction, so a reviewer can spot agreement at a glance. Part of the wider spike in #1716; this PR is just the staff-facing display, not the bulk classification tooling.

## Type of change

- [x] New feature

## How this was checked

- [x] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [x] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [x] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [x] Documentation updated, or not needed

New request specs cover staff-only gating, the panel staying hidden with no data, and the agreement badge; the full `divisions_controller_spec.rb` suite passes. Verified through those specs (real staff session, real rendered HTML) rather than a manual browser check, no Node/Playwright available in the environment this was built in, so the Bootstrap collapse toggle itself (same `data-toggle="collapse"` pattern already used for the navbar) hasn't been eyeballed in a browser yet. Worth a quick look on staging before taking this out of draft.

needs:
  - #1735 

The model changed partway through this branch, so each commit's trailer names the one that produced it - six sonnet, fourteen opus.

Assisted-by: Claude Code:claude-sonnet-5
Assisted-by: Claude Code:claude-opus-5

cc @C0smicCactus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Staff with editing access can view AI-generated policy suggestions on division pages.
  - Suggestions show model classifications, errors, proposed and existing policies, agreement counts, voting details, and reasoning.
  - When models unanimously recommend an unlinked existing policy, staff can quickly create the division-policy link.

- **Improvements**
  - Policy descriptions include clearer names and deleted or unresolved policy details.
  - Unsupported model results are filtered out, and model names use readable labels.
  - Expandable suggestion details respond correctly to their expanded or collapsed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->