### PR TITLE
Fix crash on every create/update/destroy of a policy-division connection

### DIFF
--- a/app/controllers/divisions_controller.rb
+++ b/app/controllers/divisions_controller.rb
@@ -134,10 +134,10 @@ class DivisionsController < ApplicationController
   # TODO: Move this to a policy_division controller
   def update_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
-    policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
-    authorize policy_division, :update?
+    @policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
+    authorize @policy_division, :update?
 
-    if policy_division.update(policy_division_params)
+    if @policy_division.update(policy_division_params)
       flash[:notice] = "Updated policy connection"
     else
       flash[:error] = "Could not update policy connection"
@@ -150,10 +150,10 @@ class DivisionsController < ApplicationController
   # TODO: Move this to a policy_division controller
   def destroy_policy_division
     division = Division.in_house(params[:house]).find_by!(date: params[:date], number: params[:number])
-    policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
-    authorize policy_division, :destroy?
+    @policy_division = PolicyDivision.find_by!(division: division, policy: params[:policy_id])
+    authorize @policy_division, :destroy?
 
-    if policy_division.destroy
+    if @policy_division.destroy
       flash[:notice] = "Removed policy connection"
     else
       flash[:error] = "Could not remove policy connection"
@@ -180,7 +180,9 @@ class DivisionsController < ApplicationController
             .find_by(date: date, number: number)
   end
 
+  # `policy` here isn't a local variable, it's Pundit's own policy(record) helper - calling it with
+  # no arguments raised ArgumentError, crashing every create/update/destroy of a policy connection.
   def calculate_policy_person_distances
-    CalculatePolicyPersonDistancesJob.perform_later(policy)
+    CalculatePolicyPersonDistancesJob.perform_later(@policy_division.policy) if @policy_division&.policy
   end
 end

--- a/spec/requests/divisions_controller_spec.rb
+++ b/spec/requests/divisions_controller_spec.rb
@@ -133,5 +133,43 @@ describe DivisionsController, type: :request do
         compare_static "/divisions/senate/2009-11-25/8", form_params: { submit: "Save", newtitle: "A lovely new title", newdescription: "And a great new description" }
       end
     end
+
+    describe "#create_policy_division, #update_policy_division, #destroy_policy_division" do
+      # Regression coverage for a bug where the after_action recalculating PolicyPersonDistance
+      # records called Pundit's own policy(record) helper with no arguments (a bare `policy`, meant
+      # to be the connection's actual Policy) - raising ArgumentError and crashing every one of
+      # these three actions, despite the underlying save/update/destroy having already succeeded.
+      it "connects a division to a policy without erroring" do
+        division = division_representatives_2006_12_06_3
+        policy1
+
+        post "/divisions/representatives/2006-12-06/3/policies/create", params: { policy_division: { policy_id: policy1.id, vote: "aye" } }
+
+        expect(response).to redirect_to("/divisions/representatives/2006-12-06/3/policies")
+        expect(division.policy_divisions.find_by(policy: policy1)&.vote).to eq "aye"
+      end
+
+      it "updates an existing connection without erroring" do
+        division = division_representatives_2006_12_06_3
+        policy1
+        create(:policy_division, division: division, policy: policy1, vote: "aye")
+
+        patch "/divisions/representatives/2006-12-06/3/policies/#{policy1.id}", params: { policy_division: { vote: "no" } }
+
+        expect(response).to redirect_to("/divisions/representatives/2006-12-06/3/policies")
+        expect(division.policy_divisions.find_by(policy: policy1).vote).to eq "no"
+      end
+
+      it "removes an existing connection without erroring" do
+        division = division_representatives_2006_12_06_3
+        policy1
+        create(:policy_division, division: division, policy: policy1, vote: "aye")
+
+        delete "/divisions/representatives/2006-12-06/3/policies/#{policy1.id}/delete"
+
+        expect(response).to redirect_to("/divisions/representatives/2006-12-06/3/policies")
+        expect(division.policy_divisions.find_by(policy: policy1)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## What and why

The `after_action` recalculating `PolicyPersonDistance` records called `CalculatePolicyPersonDistancesJob.perform_later(policy)`, but `policy` wasn't a local variable, it resolved to Pundit's own `policy(record)` helper, called here with no arguments. That raised `ArgumentError`, and since `after_action` runs synchronously in the same request, it replaced the intended redirect with a 500, on all three of `create_policy_division`, `update_policy_division` and `destroy_policy_division`. The underlying save/update/destroy had already succeeded by that point, so the connection change stuck, but the user saw an error page and `PolicyPersonDistance` recalculation never ran (the job was never actually enqueued, the crash happened while evaluating its argument). `update_policy_division` and `destroy_policy_division` also held their `PolicyDivision` in a local variable, so `calculate_policy_person_distances` had no way to reach it even once the wrong `policy` call was fixed; both now use `@policy_division`, matching `create_policy_division`.

## Type of change

- [x] Bug fix

## How this was checked

- [ ] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

There was no test coverage at all for these three actions, which is presumably how this went unnoticed. Added request specs for all three (confirmed they fail without the fix, reproducing the exact `ArgumentError`). Full `divisions_controller_spec.rb` passes (49 examples), rubocop clean.

Assisted-by: Claude Code:claude-sonnet-5

Closes #1737