### PR TITLE
Handle a deleted user in the policy history page and change-alert emails

### DIFF
--- a/app/helpers/policies_helper.rb
+++ b/app/helpers/policies_helper.rb
@@ -235,17 +235,22 @@ module PoliciesHelper
     end
   end
 
+  # Returns nil if the user who made this edit has since been deleted (see Policy#last_edited_by
+  # for why that can happen even though a policy's own owner can't be deleted).
   def version_author(version)
     if version.is_a?(WikiMotion)
       version.user
     else
-      User.find(version.whodunnit)
+      User.find_by(id: version.whodunnit)
     end
   end
 
   def version_attribution_text(version)
     user = version_author(version)
-    "By #{user.name} at #{version.created_at.strftime('%I:%M%p - %d %b %Y')}\n#{user_url(user, only_path: false)}"
+    timestamp = version.created_at.strftime("%I:%M%p - %d %b %Y")
+    return "By an unknown user at #{timestamp}" unless user
+
+    "By #{user.name} at #{timestamp}\n#{user_url(user, only_path: false)}"
   end
 
   def capitalise_initial_character(text)

--- a/app/views/alert_mailer/policy_updated.html.haml
+++ b/app/views/alert_mailer/policy_updated.html.haml
@@ -10,7 +10,10 @@
   = version_sentence(@version)
 
 %p.small.object-primary
-  = link_to version_author(@version).name, version_author(@version)
+  - if (author = version_author(@version))
+    = link_to author.name, author
+  - else
+    Unknown user
   %span.text-muted.small
     = @version.created_at.strftime("%l:%M%p - %d %b %Y")
 

--- a/spec/helpers/policies_helper_spec.rb
+++ b/spec/helpers/policies_helper_spec.rb
@@ -126,4 +126,40 @@ describe PoliciesHelper, type: :helper do
       end
     end
   end
+
+  describe "#version_author" do
+    it "returns the user who made the edit" do
+      user = create(:confirmed_user)
+      version = instance_double(PaperTrail::Version, whodunnit: user.id.to_s)
+
+      expect(helper.version_author(version)).to eq user
+    end
+
+    it "returns the WikiMotion's own user without touching whodunnit" do
+      wiki_motion = build(:wiki_motion, user: build(:confirmed_user))
+
+      expect(helper.version_author(wiki_motion)).to eq wiki_motion.user
+    end
+
+    it "returns nil when that user has since been deleted, rather than raising" do
+      version = instance_double(PaperTrail::Version, whodunnit: "0")
+
+      expect(helper.version_author(version)).to be_nil
+    end
+  end
+
+  describe "#version_attribution_text" do
+    it "names the user and when they made the edit" do
+      user = create(:confirmed_user, name: "Henare Degan")
+      version = instance_double(PaperTrail::Version, whodunnit: user.id.to_s, created_at: Time.zone.local(2026, 1, 2, 3, 4))
+
+      expect(helper.version_attribution_text(version)).to eq "By Henare Degan at 03:04AM - 02 Jan 2026\nhttp://test.host/users/#{user.id}"
+    end
+
+    it "says the user is unknown when they've since been deleted, rather than raising" do
+      version = instance_double(PaperTrail::Version, whodunnit: "0", created_at: Time.zone.local(2026, 1, 2, 3, 4))
+
+      expect(helper.version_attribution_text(version)).to eq "By an unknown user at 03:04AM - 02 Jan 2026"
+    end
+  end
 end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe AlertMailer do
       end
     end
 
+    context "when the user who made the edit has since been deleted" do
+      let(:mail) do
+        policy
+        user1.destroy!
+        described_class.policy_updated(policy, policy.versions.last, user2)
+      end
+
+      it "shows the edit is by an unknown user instead of erroring" do
+        expect(mail.html_part.body.to_s).to include("Unknown user")
+        expect(mail.text_part.body.to_s).to include("By an unknown user")
+      end
+    end
+
     context "with associated division text changed" do
       let(:division) { create(:division, number: 1) }
       let(:wiki_motion) { create(:wiki_motion, user: user1, division: division) }


### PR DESCRIPTION
## What and why

Same root cause as #1734: `PoliciesHelper#version_author` called `User.find(version.whodunnit)`, which raised `ActiveRecord::RecordNotFound` whenever the user who made a PaperTrail-tracked edit no longer exists. `User#policies` is `dependent: :restrict_with_exception`, which stops a policy's owner from being deleted, but not someone who merely edited it, so that account could still be removed later.

This is reachable from a policy's history page and a person's own history/profile pages (both render `_history_list.html.haml`, already safe once `version_author` returns nil, since `name_with_badge` already handles that from #1734), and from the "policy updated" alert email sent to watchers, whose HTML and text parts both called `.name` directly on the result. `version_author` now uses `find_by`, returning nil instead of raising; the email's HTML template and `version_attribution_text` (the plain-text version) now say "unknown user" instead of raising on a nil result.

Closes #1738

## Type of change

- [x] Bug fix

## How this was checked

- [ ] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

Added specs reproducing both crashes end to end (confirmed they fail without the fix) plus direct coverage of `version_author` and `version_attribution_text`. 57 examples pass across the touched spec files, rubocop clean.

Assisted-by: Claude Code:claude-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Policy update notifications now continue to display correctly when the editing user has been deleted.
  - Deleted users are shown as “Unknown user” instead of causing an error.
  - Existing author links and attribution timestamps remain available when the user exists.

- **Tests**
  - Added coverage for missing users, attribution formatting, profile links, and HTML and text email notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->