### PR TITLE
Let a failed AI classification be retried

### DIFF
--- a/app/models/ai_policy_suggestion.rb
+++ b/app/models/ai_policy_suggestion.rb
@@ -11,11 +11,13 @@ class AiPolicySuggestion < ApplicationRecord
   validates :match, inclusion: { in: %w[existing new] }, allow_nil: true
   validates :direction, inclusion: { in: %w[for against] }, allow_nil: true
 
-  def self.create_from_result!(division, result)
-    create!(
-      division: division,
+  # Overwrites any row already held for this division and model. There's a unique index on the
+  # pair, so a plain create raises once a failed attempt has left an errored row behind, which is
+  # exactly when a retry needs to write.
+  def self.save_from_result!(division, result)
+    suggestion = find_or_initialize_by(division: division, model: result.model)
+    suggestion.update!(
       policy: result.policy,
-      model: result.model,
       match: result.match,
       direction: result.direction,
       proposed_policy_name: result.new_policy_name,
@@ -24,6 +26,7 @@ class AiPolicySuggestion < ApplicationRecord
       raw_response: result.raw,
       error: result.error
     )
+    suggestion
   end
 
   def summary

--- a/lib/tasks/ai_classification.rake
+++ b/lib/tasks/ai_classification.rake
@@ -35,11 +35,11 @@ namespace :ai do
 
     DivisionPolicyClassifier::MODELS.each do |label, model_id|
       suggestion = AiPolicySuggestion.find_by(division: division, model: model_id)
-      if suggestion
+      if suggestion && suggestion.error.blank?
         puts "== #{label} (already classified, skipping) =="
       else
         result = classifier.classify_with(model_id)
-        suggestion = AiPolicySuggestion.create_from_result!(division, result)
+        suggestion = AiPolicySuggestion.save_from_result!(division, result)
         puts "== #{label} =="
       end
 

--- a/spec/models/ai_policy_suggestion_spec.rb
+++ b/spec/models/ai_policy_suggestion_spec.rb
@@ -25,7 +25,7 @@ describe AiPolicySuggestion do
     end
   end
 
-  describe ".create_from_result!" do
+  describe ".save_from_result!" do
     it "maps every field from the classifier's result" do
       division = create(:division)
       policy = create(:policy)
@@ -38,7 +38,7 @@ describe AiPolicySuggestion do
         raw: '{"match": "existing"}'
       )
 
-      suggestion = described_class.create_from_result!(division, result)
+      suggestion = described_class.save_from_result!(division, result)
 
       expect(suggestion.division).to eq division
       expect(suggestion.policy).to eq policy
@@ -47,6 +47,21 @@ describe AiPolicySuggestion do
       expect(suggestion.direction).to eq "for"
       expect(suggestion.reasoning).to eq "because"
       expect(suggestion.raw_response).to eq '{"match": "existing"}'
+    end
+
+    it "overwrites a failed attempt rather than raising on the unique index" do
+      division = create(:division)
+      policy = create(:policy)
+      described_class.create!(division: division, model: "test.model-v1:0", error: "ServiceUnavailable")
+      result = DivisionPolicyClassifier::Result.new(
+        model: "test.model-v1:0", match: "existing", policy: policy, direction: "for"
+      )
+
+      suggestion = described_class.save_from_result!(division, result)
+
+      expect(suggestion.error).to be_nil
+      expect(suggestion.policy).to eq policy
+      expect(described_class.where(division: division, model: "test.model-v1:0").count).to eq 1
     end
   end
 


### PR DESCRIPTION
## What and why

`ai:classify_division` skipped any division and model that already had an `AiPolicySuggestion` row, without checking whether that row recorded a failure. A transient Bedrock error therefore wrote an errored row that was then treated as a finished classification for good, so the division could never be classified again — despite the task's own description promising it's safe to re-run.

Skipping now requires the stored row to have no error. That alone would crash: there's a unique index on `[division_id, model]` and `create_from_result!` called `create!`, so writing the retry raised `ActiveRecord::RecordNotUnique`. It's an upsert now, renamed `save_from_result!` since it no longer only creates.

Closes #1742.

## Type of change

- [x] Bug fix

## How this was checked

- [ ] Checked the affected area on my own or a staging system
- [x] Ran the automated tests
- [ ] Ran `/code-review` (or equivalent): fixed any concerns (and rechecked), linked follow-up issues below, or noted why they are not important below
- [ ] GitHub Actions tests: likewise fixed so they pass or linked a follow-up issue / replied why not important directly on each comment (reviewer will mark resolved as part of review)
- [ ] Documentation updated, or not needed

A new spec writes an errored row and then retries, which fails against the old code with the exact production error (`Duplicate entry '8-test.model-v1:0' for key 'index_ai_policy_suggestions_on_division_id_and_model'`) and passes with the fix. 390 examples across models, services, lib, helpers and requests pass; rubocop clean.

Worth knowing for anyone reproducing this locally: my test database still had that index as non-unique, because it predated `eecf7f7f6` ("Make the division_id/model index unique"). Until I ran `rails db:test:prepare` the retry wrote a silent duplicate row instead of raising, so the crash didn't reproduce. Anyone whose test DB is older than that commit will see the same.

The same shape exists for `AiDivisionSummary` on #1732, and needs the same fix there — that model only exists on that branch, so it can't be fixed here.

Assisted-by: Claude Code:claude-opus-5